### PR TITLE
AutoLaunchBrowser

### DIFF
--- a/packages/pico-engine/package.json
+++ b/packages/pico-engine/package.json
@@ -18,7 +18,7 @@
     "watch:test": "onchange -i src/ -- npm run test -s",
     "lint": "../../node_modules/.bin/eslint src/ && echo lint-ok",
     "runlocal": "PICO_ENGINE_HOME=. node src/cli.js",
-    "test": "npm run lint && node src/tests.js && open \"http://$([ $PICO_ENGINE_HOME] && PICO_ENGINE_HOME || echo localhost ):$([ $PORT ] &&  $PORT || echo 8080)\" && echo \"pico-engine at http://$([ $PICO_ENGINE_HOME] && PICO_ENGINE_HOME || echo localhost ):$([ $PORT ] &&  $PORT || echo 8080)\""
+    "test": "npm run lint && node src/tests.js"
   },
   "repository": {
     "type": "git",
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/Picolab/pico-engine#readme",
   "devDependencies": {
     "onchange": "^3.0.0",
+    "opn": "^4.0.2",
     "scriptsp": "^1.0.1",
     "tape": "^4.5.1",
     "temp-fs": "^0.9.9"

--- a/packages/pico-engine/package.json
+++ b/packages/pico-engine/package.json
@@ -18,7 +18,7 @@
     "watch:test": "onchange -i src/ -- npm run test -s",
     "lint": "../../node_modules/.bin/eslint src/ && echo lint-ok",
     "runlocal": "PICO_ENGINE_HOME=. node src/cli.js",
-    "test": "npm run lint && node src/tests.js"
+    "test": "npm run lint && node src/tests.js && open \"http://$([ $PICO_ENGINE_HOME] && PICO_ENGINE_HOME || echo localhost ):$([ $PORT ] &&  $PORT || echo 8080)\" && echo \"pico-engine at http://$([ $PICO_ENGINE_HOME] && PICO_ENGINE_HOME || echo localhost ):$([ $PORT ] &&  $PORT || echo 8080)\""
   },
   "repository": {
     "type": "git",

--- a/packages/pico-engine/src/index.js
+++ b/packages/pico-engine/src/index.js
@@ -1,3 +1,4 @@
+var open = require("opn");
 var startCore = require("./startCore");
 var setupServer = require("./setupServer");
 
@@ -12,7 +13,8 @@ module.exports = function(conf){
         var app = setupServer(pe);
 
         app.listen(conf.port, function(){
-            console.log(conf.host);
+            console.log("pico-engine at " + conf.host + ":" + conf.port);
+            open(conf.host + ":" + conf.port);
         });
     });
 };


### PR DESCRIPTION
From an old [PR](https://github.com/Picolab/node-pico-engine/pull/6) opened by https://github.com/burdettadam:

This will launch the browser after tests have ran during nom start command. Also prints out the url server is serving at.

<!---
@huboard:{"order":311.023325,"milestone_order":314,"custom_state":""}
-->
