### PR TITLE
Begin math module as a demonstration

### DIFF
--- a/packages/pico-engine-core/src/modules/index.js
+++ b/packages/pico-engine-core/src/modules/index.js
@@ -10,6 +10,7 @@ var sub_modules = {
     engine: require("./engine"),
     http: require("./http"),
     keys: require("./keys"),
+    math: require("./math"),
     meta: require("./meta"),
     schedule: require("./schedule"),
     time: require("./time"),

--- a/packages/pico-engine-core/src/modules/math.js
+++ b/packages/pico-engine-core/src/modules/math.js
@@ -1,0 +1,68 @@
+var _ = require("lodash");
+var crypto = require("crypto");
+var ktypes = require("krl-stdlib/types");
+var mkKRLfn = require("../mkKRLfn");
+
+var supportedHashFns = crypto.getHashes();
+
+module.exports = function(core){
+    return {
+        def: {
+
+            base64encode: mkKRLfn([
+                "str",
+            ], function(args, ctx, callback){
+                if(!_.has(args, "str")){
+                    return callback(new Error("math:base64encode needs a str string"));
+                }
+
+                var str = ktypes.toString(args.str);
+                callback(null, Buffer.from(str, "utf8").toString("base64"));
+            }),
+
+
+            base64decode: mkKRLfn([
+                "str",
+            ], function(args, ctx, callback){
+                if(!_.has(args, "str")){
+                    return callback(new Error("math:base64decode needs a str string"));
+                }
+
+                var str = ktypes.toString(args.str);
+                callback(null, Buffer.from(str, "base64").toString("utf8"));
+            }),
+
+
+            hashFunctions: mkKRLfn([
+            ], function(args, ctx, callback){
+                callback(null, supportedHashFns);
+            }),
+
+
+            hash: mkKRLfn([
+                "hashFn",
+                "toHash"
+            ], function(args, ctx, callback){
+                if(!_.has(args, "hashFn")){
+                    return callback(new Error("math:hash needs a hashFn string"));
+                }
+                if(!_.has(args, "toHash")){
+                    return callback(new Error("math:hash needs a toHash string"));
+                }
+                if(!_.includes(supportedHashFns, args.hashFn)){
+                    if(ktypes.isString(args.hashFn)){
+                        callback(new Error("math:hash doesn't recognize the hash algorithm " + args.hashFn));
+                    }else{
+                        callback(new TypeError("math:hash was given " + ktypes.toString(args.hashFn) + " instead of a hashFn string"));
+                    }
+                }
+
+                var str = ktypes.toString(args.toHash);
+                var hash = crypto.createHash(args.hashFn).update(str);
+
+                callback(null, hash.digest("hex"));
+            }),
+
+        }
+    };
+};

--- a/packages/pico-engine-core/src/modules/math.test.js
+++ b/packages/pico-engine-core/src/modules/math.test.js
@@ -1,0 +1,44 @@
+var test = require("tape");
+var cocb = require("co-callback");
+var kmath = require("./math")().def;
+
+var testErr = require("../testErr");
+
+test("module - math:*", function(t){
+    cocb.run(function*(){
+        var terr = testErr(t, kmath);
+
+        t.equals(yield kmath.base64encode({}, ["}{"]), "fXs=", "base64encode");
+        t.equals(yield kmath.base64encode({}, [null]), yield kmath.base64encode({}, ["null"]), "base64encode coreces to strings");
+
+        yield terr("base64encode", {}, [], "Error: math:base64encode needs a str string");
+
+        t.equals(yield kmath.base64decode({}, ["fXs="]), "}{", "base64decode");
+
+        yield terr("base64decode", {}, [], "Error: math:base64decode needs a str string");
+
+        t.ok(yield kmath.hashFunctions({}, []), "hashFunctions should return something");
+
+        t.equals(
+            yield kmath.hash({}, ["sha256", "hello"]),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+            "sha256 \"hello\""
+        );
+        t.equals(
+            yield kmath.hash({}, ["sha256", null]),
+            yield kmath.hash({}, ["sha256", "null"]),
+            "sha2 coerces inputs to Strings"
+        );
+        t.equals(
+            yield kmath.hash({}, ["sha256", [1, 2]]),
+            yield kmath.hash({}, ["sha256", "[Array]"]),
+            "sha2 coerces inputs to Strings"
+        );
+
+        yield terr("hash", {}, [], "Error: math:hash needs a hashFn string");
+        yield terr("hash", {}, [0], "Error: math:hash needs a toHash string");
+        yield terr("hash", {}, [0, null], "TypeError: math:hash was given 0 instead of a hashFn string");
+        yield terr("hash", {}, ["0", null], "Error: math:hash doesn't recognize the hash algorithm 0");
+
+    }, t.end);
+});

--- a/packages/pico-engine-core/src/tests.js
+++ b/packages/pico-engine-core/src/tests.js
@@ -5,6 +5,7 @@ require("./modules/http.test");
 require("./modules/time.test");
 require("./modules/engine.test");
 require("./modules/event.test");
+require("./modules/math.test");
 require("./modules/random.test");
 require("./cleanEvent.test");
 require("./runAction.test");


### PR DESCRIPTION
From an old [PR](https://github.com/Picolab/node-pico-engine-core/pull/14) opened by https://github.com/0joshuaolson1:

`base64decode` works on a best effort basis, so `"hello!"` for example decodes to `"hello"`.

farskipper added `math:sha2` as a `crypto` example (although if we wanted to get crazy we could use the streaming api, which may be faster). The `crypto` 'module' should come with any Node binary, but if someone's doing something really crazy with a custom build, they can cross that bridge when they get there. There are ways to fallback, e.g. browserify has stubs for these node apis that work in browsers.

<!---
@huboard:{"order":311.0194375,"milestone_order":315,"custom_state":""}
-->
