### PR TITLE
Weak typing

### DIFF
--- a/packages/krl-stdlib/src/index.js
+++ b/packages/krl-stdlib/src/index.js
@@ -579,24 +579,22 @@ stdlib.slice = function(ctx, val, start, end){
     if(!types.isArray(val)){
         val = [val];
     }else if(val.length === 0){
-        ctx.emit("error", new Error("Cannot .slice() an empty array"));
-        return null;
+        return [];
     }
     if(arguments.length === 2){
         return val;
     }
-    var firstIndex = types.numericCast(start);
+    var firstIndex = types.toNumberOrNull(start);
     if(firstIndex === null){
         throw new TypeError("The .slice() operator cannot use " + types.toString(start) + " as an index");
     }
     if(arguments.length === 3){
         if(firstIndex > val.length){
-            ctx.emit("error", new RangeError("Cannot .slice() an array of length " + val.length + " from 0 to " + firstIndex));
-            return null;
+            return [];
         }
         return _.slice(val, 0, firstIndex + 1);
     }
-    var secondIndex = types.numericCast(end);
+    var secondIndex = types.toNumberOrNull(end);
     if(secondIndex === null){
         throw new TypeError("The .slice() operator cannot use " + types.toString(end) + " as the other index");
     }
@@ -608,37 +606,29 @@ stdlib.slice = function(ctx, val, start, end){
     if(firstIndex >= 0 && secondIndex < val.length){
         return _.slice(val, firstIndex, secondIndex + 1);
     }
-    ctx.emit("error", new RangeError("Cannot .slice() an array of length " + val.length + " from " + firstIndex + " to " + secondIndex));
-    return null;
+    return [];
 };
-stdlib.splice = function(ctx, val, start, n_elms, value){
+stdlib.splice = function(ctx, val, start, nElements, value){
     if(!types.isArray(val)){
         val = [val];
     }else if(val.length === 0){
-        throw new Error("Cannot .splice() an empty array");
+        return [];
     }
-    if(arguments.length < 4){
-        throw new Error("The .splice() operator needs more than one argument");
-    }
-    var startIndex = types.numericCast(start);
+    var startIndex = types.toNumberOrNull(start);
     if(startIndex === null){
         throw new TypeError("The .splice() operator cannot use " + types.toString(start) + "as an index");
     }
-    if(startIndex < 0){
-        throw new RangeError("Cannot start .splice() starting at index " + startIndex);
+    startIndex = Math.min(Math.max(startIndex, 0), val.length - 1);
+
+    var n_elm = types.toNumberOrNull(nElements);
+    if(n_elm === null){
+        throw new TypeError("The .splice() operator cannot use " + types.toString(nElements) + "as a number of elements");
     }
-    if(startIndex >= val.length){
-        throw new RangeError("Cannot .splice() an array of length " + val.length + " starting at index " + startIndex);
-    }
-    var n_elms_number = types.numericCast(n_elms);
-    if(n_elms_number === null){
-        throw new TypeError("The .splice() operator cannot use " + types.toString(n_elms) + "as a number of elements");
-    }
-    if(n_elms_number < 0 || startIndex + n_elms_number > val.length){
-        n_elms_number = val.length - startIndex;
+    if(n_elm < 0 || startIndex + n_elm > val.length){
+        n_elm = val.length - startIndex;
     }
     var part1 = _.slice(val, 0, startIndex);
-    var part2 = _.slice(val, startIndex + n_elms);
+    var part2 = _.slice(val, startIndex + n_elm);
     if(arguments.length < 5){
         return _.concat(part1, part2);
     }

--- a/packages/krl-stdlib/src/index.js
+++ b/packages/krl-stdlib/src/index.js
@@ -109,7 +109,8 @@ stdlib["/"] = function(ctx, left, right){
         throw new TypeError(types.toString(left) + " cannot be divided by " + types.toString(right));
     }
     if(rightNumber === 0){
-        throw new RangeError(leftNumber + " / 0 is not a number");
+        ctx.emit("debug", "[DIVISION BY ZERO] " + leftNumber + " / 0");
+        return 0;
     }
     return leftNumber / rightNumber;
 };

--- a/packages/krl-stdlib/src/tests.js
+++ b/packages/krl-stdlib/src/tests.js
@@ -637,13 +637,14 @@ ytest("collection operators", function*(t){
     tf("slice", [veggies, 2, 0], ["corn","tomato","tomato"]);
     tf("slice", [veggies, 2], ["corn","tomato","tomato"]);
     tf("slice", [veggies, 0, 0], ["corn"]);
+    tf("slice", [veggies, null, NaN], ["corn"]);
+    tf("slice", [[], 0, 0], []);
     tf("slice", [{"0": "0"}, 0, 0], [{"0": "0"}]);
-    tf("slice", [[], _.noop], null, "error", "Error");
     tfe("slice", [veggies, _.noop], "TypeError");
     tfe("slice", [veggies, 1, _.noop], "TypeError");
     tfe("slice", [veggies, -1, _.noop], "TypeError");
-    tf("slice", [veggies, 14], null, "error", "RangeError");
-    tf("slice", [veggies, 2, -1], null, "error", "RangeError");
+    tf("slice", [veggies, 14], []);
+    tf("slice", [veggies, 2, -1], []);
     t.deepEquals(veggies, ["corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"], "should not be mutated");
 
     tf("splice", [veggies, 1, 4], ["corn","lettuce","sprouts"]);
@@ -653,12 +654,18 @@ ytest("collection operators", function*(t){
     tf("splice", [veggies, 1, 10], ["corn"]);
     tf("splice", [veggies, 1, 10, "liver"], ["corn", "liver"]);
     tf("splice", [veggies, 1, 10, []], ["corn"]);
-    tfe("splice", [[], NaN], "Error");
-    tfe("splice", [void 0, NaN, []], "TypeError");
-    tfe("splice", [void 0, -1, []], "RangeError");
-    tfe("splice", [veggies, 7, []], "RangeError");
-    tfe("splice", [veggies, 6, []], "TypeError");
-    tf("splice", [void 0, 0, 0, []], [void 0]);
+    tf("splice", [[], 0, 1], []);
+    tf("splice", [[], NaN], []);
+    tfe("splice", [veggies, _.noop, 1] , "TypeError");
+    tfe("splice", [veggies, 0, _.noop] , "TypeError");
+    tf("splice", [veggies, 0, 0], veggies);
+    tf("splice", [veggies, 0, veggies.length], []);
+    tf("splice", [veggies, 0, 999], []);
+    tf("splice", [veggies, 0, -1], []);
+    tf("splice", [veggies, 0, -999], []);
+    tf("splice", [veggies, -1, 0], veggies);
+    tf("splice", [veggies, -999, 0], veggies);
+    tf("splice", [void 0, 0, 0], [void 0]);
     t.deepEquals(veggies, ["corn","tomato","tomato","tomato","sprouts","lettuce","sprouts"], "should not be mutated");
 
     var to_sort = [5, 3, 4, 1, 12];

--- a/packages/krl-stdlib/src/tests.js
+++ b/packages/krl-stdlib/src/tests.js
@@ -184,8 +184,13 @@ test("infix operators", function(t){
 
     tf("/", [4, 2], 2);
     tfe("/", ["two", 1], "TypeError");
+    tf("/", ["2", 1], 2);
     tfe("/", [1, _.noop], "TypeError");
-    tfe("/", ["1", "0"], "RangeError");
+    t.equals(stdlib["/"]({
+        emit: function(kind, err){
+            t.equals(kind + err, "debug[DIVISION BY ZERO] 9 / 0");
+        }
+    }, 9, 0), 0);
 
     tf("%", [4, 2], 0);
     tf("%", ["1", "0"], 0);

--- a/packages/krl-stdlib/src/types.js
+++ b/packages/krl-stdlib/src/types.js
@@ -94,19 +94,6 @@ types.cleanNulls = function(val){
     return val;
 };
 
-types.numericCast = function(val, round){
-    var roundFn = round ? _.round : _.identity;
-    if(types.isNumber(val)){
-        return roundFn(val);
-    }
-    if(!types.isString(val)){
-        return null;
-    }
-    var n = parseFloat(val);
-    return types.isNumber(n)
-        ? roundFn(n)
-        : null;
-};
 
 types.toNumberOrNull = function(val){
     switch(types.typeOf(val)){

--- a/packages/krl-stdlib/src/types.js
+++ b/packages/krl-stdlib/src/types.js
@@ -108,6 +108,27 @@ types.numericCast = function(val, round){
         : null;
 };
 
+types.toNumberOrNull = function(val){
+    switch(types.typeOf(val)){
+    case "Null":
+        return 0;
+    case "Boolean":
+        return val ? 1 : 0;
+    case "String":
+        var n = parseFloat(val);
+        return types.isNumber(n) ? n : null;
+    case "Number":
+        return val;
+    case "Array":
+    case "Map":
+        return _.size(val);
+    case "RegExp":
+    case "Function":
+    case "Action":
+    }
+    return null;
+};
+
 types.toString = function(val){
     var val_type = types.typeOf(val);
     if(val_type === "String"){

--- a/packages/pico-engine-core/src/index.test.js
+++ b/packages/pico-engine-core/src/index.test.js
@@ -528,7 +528,7 @@ test("PicoEngine - io.picolabs.operators ruleset", function(t){
                     ".substr(5)": "is a string",
                     ".substr(5, 4)": "is a",
                     ".substr(5, -5)": "is a s",
-                    ".substr(25)": null,
+                    ".substr(25)": "",
                     ".uc()": "HELLO WORLD"
                 }
             ],

--- a/packages/pico-engine-core/src/modules/random.js
+++ b/packages/pico-engine-core/src/modules/random.js
@@ -5,20 +5,26 @@ var mkKRLfn = require("../mkKRLfn");
 var randomWords = require("random-words");
 
 var fixLowerUpperArgs = function(args, round){
-    var lowerNum = ktypes.numericCast(args.lower, round);
-    var lowerIsNull = ktypes.isNull(lowerNum);
+    var lowerNum = ktypes.toNumberOrNull(args.lower);
+    if(round && lowerNum !== null){
+        lowerNum = _.round(lowerNum);
+    }
 
-    var upperNum = ktypes.numericCast(args.upper, round);
+    var upperNum = ktypes.toNumberOrNull(args.upper);
+    if(round && upperNum !== null){
+        upperNum = _.round(upperNum);
+    }
+
     var upper;
 
-    if(ktypes.isNull(upperNum)){
-        upper = lowerIsNull ? 1 : 0;
+    if(upperNum === null){
+        upper = lowerNum === null ? 1 : 0;
     }else{
         upper = upperNum;
     }
 
     return {
-        lower: lowerIsNull ? 0 : lowerNum,
+        lower: lowerNum === null ? 0 : lowerNum,
         upper: upper
     };
 };


### PR DESCRIPTION
What spurred this on was:
```krl
select when a a mileage re#(.*)# setting(m)
if m > 200 then
  ...
```
**>** was not very friendly about the attribute being a string.

I changed it so all comparison operators now try to convert both arguments to a number. If one or both fail to convert, then it converts them to strings and compares that.
```js
"300" > "200" is the same as  300  > 200
"300" >  200  is the same as  300  > 200
"wat" >  200  is the same as "wat" > "200"
 noop >  200  is the same as "[Function]" > "200"
```

I also changed the logic for `.as("Number")`
```js
null.as("Number") -> 0

false.as("Number") -> 0
true.as("Number") -> 1

"200".as("Number") -> 200
"wat".as("Number") -> null  // if the string cannot be parsed into a number, return null

// arrays and maps return their size
[].as("Number") -> 0
["a", "b"].as("Number") -> 2
{"a": a, "b": b, "c": c}.as("Number") -> 3

// other types return null
re#foo#.as("Number") -> null
send_directive.as("Number") -> null
```
These same number conversion rules are used everywhere.

Another change I made was making `.substr()`, `.slice()`, and `.splice()` more forgiving by return an empty string/array instead of throwing an error when the range is out of bounds. i.e.
```js
"foo".substr(1000) -> "" // instead of throwing a RangeError
```

Finally, division by zero. In many situations 0 is an acceptable response. So instead of breaking and throwing an error, it now just returns 0 and emits a debug message. i.e.
```js
9 / 0  -> 0 // and emits "[DIVISION BY ZERO] 9 / 0"
```