### PR TITLE
Select where

### DIFF
--- a/packages/krl-compiler/src/c/EventExpression.js
+++ b/packages/krl-compiler/src/c/EventExpression.js
@@ -64,7 +64,7 @@ module.exports = function(ast, comp, e){
 
     _.each(ast.setting, function(s, i){
         fn_body.push(e(";",
-            e("call", e("id", "ctx.scope.set", s.loc), [
+            e("call", e("id", "setting", s.loc), [
                 e("str", s.value, s.loc),
                 e("get", e("id", "matches", s.loc), e("num", i, s.loc), s.loc)
             ], s.loc), s.loc));
@@ -94,5 +94,5 @@ module.exports = function(ast, comp, e){
 
     fn_body.push(e("return", e(true)));
 
-    return e("genfn", ["ctx", "aggregateEvent", "getAttrString"], fn_body);
+    return e("genfn", ["ctx", "aggregateEvent", "getAttrString", "setting"], fn_body);
 };

--- a/packages/krl-compiler/src/c/EventExpression.js
+++ b/packages/krl-compiler/src/c/EventExpression.js
@@ -35,12 +35,6 @@ module.exports = function(ast, comp, e){
         fn_body.push(e("var", "matches", e("array", [])));
     }
 
-    if(ast.where){
-        fn_body.push(e("if", e("!", comp(ast.where, {
-            identifiers_are_event_attributes: true
-        })), e("return", e("false"))));
-    }
-
     _.each(ast.setting, function(s, i){
         fn_body.push(e(";",
             e("call", e("id", "ctx.scope.set", s.loc), [
@@ -48,6 +42,12 @@ module.exports = function(ast, comp, e){
                 e("get", e("id", "matches", s.loc), e("num", i, s.loc), s.loc)
             ], s.loc), s.loc));
     });
+
+    if(ast.where){
+        fn_body.push(e("if", e("!", comp(ast.where, {
+            identifiers_are_event_attributes: true
+        })), e("return", e("false"))));
+    }
 
     if(ast.aggregator){
         fn_body.push(e(";",

--- a/packages/krl-compiler/src/c/EventExpression.js
+++ b/packages/krl-compiler/src/c/EventExpression.js
@@ -3,6 +3,10 @@ var _ = require("lodash");
 module.exports = function(ast, comp, e){
     //FYI the graph allready vetted the domain and type
 
+    if(ast.deprecated){
+        comp.warn(ast.loc, "DEPRECATED SYNTAX - " + ast.deprecated);
+    }
+
     var fn_body = [];
 
     if(ast.where){

--- a/packages/krl-compiler/src/c/Identifier.js
+++ b/packages/krl-compiler/src/c/Identifier.js
@@ -1,8 +1,3 @@
-var callModuleFn = require("../utils/callModuleFn");
-
 module.exports = function(ast, comp, e, context){
-    if(context && context.identifiers_are_event_attributes){
-        return callModuleFn(e, "event", "attr", e("array", [e("str", ast.value)]), ast.loc);
-    }
     return e("call", e("id", "ctx.scope.get"), [e("str", ast.value)]);
 };

--- a/packages/krl-compiler/src/tests.js
+++ b/packages/krl-compiler/src/tests.js
@@ -158,6 +158,15 @@ test("compiler errors", function(t){
         "DEPRECATED change `keys:foo(name)` to `keys:foo{name}`"
     );
 
+    tstWarn(
+        "ruleset a{rule a{select when a a bb re#.# where a > 0 setting(bb)}}",
+        "DEPRECATED SYNTAX - Move the `where` clause to be after the `setting`"
+    );
+    tstWarn(
+        "ruleset a{rule a{select when a a setting(bb)}}",
+        "DEPRECATED SYNTAX - What are you `setting`? There are no attribute matches"
+    );
+
     t.end();
 });
 

--- a/packages/krl-generator/src/g/EventExpression.js
+++ b/packages/krl-generator/src/g/EventExpression.js
@@ -13,9 +13,6 @@ module.exports = function(ast, ind, gen){
     }else if(_.size(pairs) === 1){
         src += " " + pairs.join(" ");
     }
-    if(ast.where){
-        src += " where " + gen(ast.where);
-    }
     if(!_.isEmpty(ast.setting)){
         if(_.size(pairs) > 1){
             src += "\n" + ind(2);
@@ -25,6 +22,9 @@ module.exports = function(ast, ind, gen){
         src += "setting(" + _.map(ast.setting, function(a){
             return gen(a, 1);
         }).join(", ") + ")";
+    }
+    if(ast.where){
+        src += " where " + gen(ast.where);
     }
     return src;
 };

--- a/packages/krl-parser/spec.md
+++ b/packages/krl-parser/spec.md
@@ -142,8 +142,8 @@ rule hello {
       "event_domain": DOMAIN,
       "event_type": TYPE,
       "event_attrs": [  ],
-      "where": null,
       "setting": [  ],
+      "where": null,
       "aggregator": null
     },
     "within": null
@@ -212,8 +212,8 @@ select when A B
   "event_domain": A,
   "event_type": B,
   "event_attrs": [  ],
-  "where": null,
   "setting": [  ],
+  "where": null,
   "aggregator": null
 }
 
@@ -229,10 +229,10 @@ select when A B attr re#^(.*)$# setting(val)
       "value": {value: /^(.*)$/, type:"RegExp"}
     }
   ],
-  "where": null,
   "setting": [
     {value: "val", type:"Identifier"}
   ],
+  "where": null,
   "aggregator": null
 }
 
@@ -246,8 +246,8 @@ select when A A or B B
       "event_domain": A,
       "event_type": A,
       "event_attrs": [  ],
-      "where": null,
       "setting": [  ],
+      "where": null,
       "aggregator": null
     },
     {
@@ -255,8 +255,8 @@ select when A A or B B
       "event_domain": B,
       "event_type": B,
       "event_attrs": [  ],
-      "where": null,
       "setting": [  ],
+      "where": null,
       "aggregator": null
     }
   ]
@@ -273,8 +273,8 @@ select when any 2 (A A, B B, C C)
       "event_domain": A,
       "event_type": A,
       "event_attrs": [  ],
-      "where": null,
       "setting": [  ],
+      "where": null,
       "aggregator": null
     },
     {
@@ -282,8 +282,8 @@ select when any 2 (A A, B B, C C)
       "event_domain": B,
       "event_type": B,
       "event_attrs": [  ],
-      "where": null,
       "setting": [  ],
+      "where": null,
       "aggregator": null
     },
     {
@@ -291,8 +291,8 @@ select when any 2 (A A, B B, C C)
       "event_domain": C,
       "event_type": C,
       "event_attrs": [  ],
-      "where": null,
       "setting": [  ],
+      "where": null,
       "aggregator": null
     }
   ]

--- a/packages/krl-parser/src/grammar.js
+++ b/packages/krl-parser/src/grammar.js
@@ -1,7 +1,7 @@
-// Generated automatically by nearley
+// Generated automatically by nearley, version 2.11.1
 // http://github.com/Hardmath123/nearley
 (function () {
-function id(x) {return x[0]; }
+function id(x) { return x[0]; }
 
 
 var flatten = function(toFlatten){
@@ -657,24 +657,61 @@ var grammar = {
     {"name": "event_exp_fns", "symbols": [tok_repeat, "PositiveInteger", tok_OPEN_PAREN, "IndividualEventExpression", tok_CLSE_PAREN, "event_exp_fns$ebnf$2"], "postprocess": eventGroupOp("repeat", 1, 3, 5)},
     {"name": "event_exp_base", "symbols": [tok_OPEN_PAREN, "EventExpression", tok_CLSE_PAREN], "postprocess": getN(1)},
     {"name": "event_exp_base", "symbols": ["IndividualEventExpression"], "postprocess": id},
-    {"name": "IndividualEventExpression$ebnf$1", "symbols": []},
-    {"name": "IndividualEventExpression$ebnf$1", "symbols": ["IndividualEventExpression$ebnf$1", "event_exp_attribute_pair"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
+    {"name": "IndividualEventExpression$ebnf$1$subexpression$1$ebnf$1", "symbols": ["event_exp_attribute_pair"]},
+    {"name": "IndividualEventExpression$ebnf$1$subexpression$1$ebnf$1", "symbols": ["IndividualEventExpression$ebnf$1$subexpression$1$ebnf$1", "event_exp_attribute_pair"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
+    {"name": "IndividualEventExpression$ebnf$1$subexpression$1$ebnf$2$subexpression$1", "symbols": [tok_setting, tok_OPEN_PAREN, "Identifier_list_body", tok_CLSE_PAREN]},
+    {"name": "IndividualEventExpression$ebnf$1$subexpression$1$ebnf$2", "symbols": ["IndividualEventExpression$ebnf$1$subexpression$1$ebnf$2$subexpression$1"], "postprocess": id},
+    {"name": "IndividualEventExpression$ebnf$1$subexpression$1$ebnf$2", "symbols": [], "postprocess": function(d) {return null;}},
+    {"name": "IndividualEventExpression$ebnf$1$subexpression$1", "symbols": ["IndividualEventExpression$ebnf$1$subexpression$1$ebnf$1", "IndividualEventExpression$ebnf$1$subexpression$1$ebnf$2"]},
+    {"name": "IndividualEventExpression$ebnf$1", "symbols": ["IndividualEventExpression$ebnf$1$subexpression$1"], "postprocess": id},
+    {"name": "IndividualEventExpression$ebnf$1", "symbols": [], "postprocess": function(d) {return null;}},
     {"name": "IndividualEventExpression$ebnf$2$subexpression$1", "symbols": [tok_where, "event_exp_where"]},
     {"name": "IndividualEventExpression$ebnf$2", "symbols": ["IndividualEventExpression$ebnf$2$subexpression$1"], "postprocess": id},
     {"name": "IndividualEventExpression$ebnf$2", "symbols": [], "postprocess": function(d) {return null;}},
-    {"name": "IndividualEventExpression$ebnf$3$subexpression$1", "symbols": [tok_setting, tok_OPEN_PAREN, "Identifier_list", tok_CLSE_PAREN]},
-    {"name": "IndividualEventExpression$ebnf$3", "symbols": ["IndividualEventExpression$ebnf$3$subexpression$1"], "postprocess": id},
-    {"name": "IndividualEventExpression$ebnf$3", "symbols": [], "postprocess": function(d) {return null;}},
-    {"name": "IndividualEventExpression", "symbols": ["Identifier", "Identifier", "IndividualEventExpression$ebnf$1", "IndividualEventExpression$ebnf$2", "IndividualEventExpression$ebnf$3"], "postprocess": 
+    {"name": "IndividualEventExpression", "symbols": ["Identifier", "Identifier", "IndividualEventExpression$ebnf$1", "IndividualEventExpression$ebnf$2"], "postprocess": 
         function(data){
           return {
             type: 'EventExpression',
             loc: mkLoc(data),
             event_domain: data[0],
             event_type: data[1],
-            event_attrs: data[2],
+            event_attrs: (data[2] && data[2][0]) || [],
+            setting: (data[2] && data[2][1] && data[2][1][2]) || [],
             where: data[3] && data[3][1],
-            setting: (data[4] && data[4][2]) || [],
+            aggregator: null//this is set by EventAggregator
+          };
+        }
+        },
+    {"name": "IndividualEventExpression$ebnf$3", "symbols": []},
+    {"name": "IndividualEventExpression$ebnf$3", "symbols": ["IndividualEventExpression$ebnf$3", "event_exp_attribute_pair"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
+    {"name": "IndividualEventExpression", "symbols": ["Identifier", "Identifier", "IndividualEventExpression$ebnf$3", tok_where, "event_exp_where", tok_setting, tok_OPEN_PAREN, "Identifier_list", tok_CLSE_PAREN], "postprocess": 
+        function(data){
+          return {
+            deprecated: "Move the `where` clause to be after the `setting`",
+        
+            type: 'EventExpression',
+            loc: mkLoc(data),
+            event_domain: data[0],
+            event_type: data[1],
+            event_attrs: data[2],
+            where: data[4],
+            setting: data[7],
+            aggregator: null//this is set by EventAggregator
+          };
+        }
+        },
+    {"name": "IndividualEventExpression", "symbols": ["Identifier", "Identifier", tok_setting, tok_OPEN_PAREN, "Identifier_list", tok_CLSE_PAREN], "postprocess": 
+        function(data){
+          return {
+            deprecated: "What are you `setting`? There are no attribute matches",
+        
+            type: 'EventExpression',
+            loc: mkLoc(data),
+            event_domain: data[0],
+            event_type: data[1],
+            event_attrs: [],
+            where: null,
+            setting: data[4],
             aggregator: null//this is set by EventAggregator
           };
         }

--- a/packages/krl-parser/tests/parser.test.js
+++ b/packages/krl-parser/tests/parser.test.js
@@ -98,14 +98,14 @@ mk.unary = function(op, arg){
         arg: arg
     };
 };
-mk.ee = function(domain, type, attrs, where, setting, aggregator){
+mk.ee = function(domain, type, attrs, setting, where, aggregator){
     return {
         type: "EventExpression",
         event_domain: mk.id(domain),
         event_type: mk.id(type),
         event_attrs: attrs || [],
-        where: where || null,
         setting: setting ? setting.map(mk.id) : [],
+        where: where || null,
         aggregator: aggregator || null
     };
 };
@@ -1157,10 +1157,22 @@ test("EventExpression", function(t){
         aggregator: null
     });
 
-    testEE("a b setting(c) or d e setting(f) before g h", mk.eventOp("or", [
-        mk.ee("a", "b", [], null, ["c"]),
+    testEE("a b a re#.# setting(c) or d e a re#.# setting(f) before g h", mk.eventOp("or", [
+        mk.ee("a", "b", [
+            {
+                type: "AttributeMatch",
+                key: mk.id("a"),
+                value: mk(/./)
+            }
+        ], ["c"]),
         mk.eventOp("before", [
-            mk.ee("d", "e", [], null, ["f"]),
+            mk.ee("d", "e", [
+                {
+                    type: "AttributeMatch",
+                    key: mk.id("a"),
+                    value: mk(/./)
+                }
+            ], ["f"]),
             mk.ee("g", "h")
         ])
     ]));
@@ -1205,7 +1217,7 @@ test("EventExpression", function(t){
     testEE("count 5 (a b) max(d)", mk.eventGroupOp(
         "count",
         mk(5),
-        mk.ee("a", "b", [], null, [], {
+        mk.ee("a", "b", [], [], null, {
             type: "EventAggregator",
             op: "max",
             args: [mk.id("d")]
@@ -1216,7 +1228,7 @@ test("EventExpression", function(t){
         testEE("repeat 5 (a b) " + op + "(c)", mk.eventGroupOp(
             "repeat",
             mk(5),
-            mk.ee("a", "b", [], null, [], {
+            mk.ee("a", "b", [], [], null, {
                 type: "EventAggregator",
                 op: op,
                 args: [mk.id("c")]

--- a/packages/krl-parser/tests/unparse.js
+++ b/packages/krl-parser/tests/unparse.js
@@ -130,6 +130,11 @@ module.exports = function(options){
             stack.push({literal: "<<hello #{"});
             stack.push("Expression");
             stack.push({literal: "}!>>"});
+        }else if(currentname === "event_exp_where"){
+            // fixing error when it comes up with RegExp right away
+            stack.push("Identifier");
+            stack.push({literal: ">"});
+            stack.push("Expression");
         }else if(typeof currentname === "string"){
             _.each(selectRule(currentname).symbols, function(symbol){
                 stack.push(symbol);

--- a/packages/pico-engine-core/src/DB.js
+++ b/packages/pico-engine-core/src/DB.js
@@ -754,24 +754,24 @@ module.exports = function(opts){
         //
         // event state machine and aggregators
         //
-        getStateMachineState: function(pico_id, rule, callback){
+        getStateMachine: function(pico_id, rule, callback){
             var key = ["state_machine", pico_id, rule.rid, rule.name];
-            ldb.get(key, function(err, curr_state){
+            ldb.get(key, function(err, data){
                 if(err){
                     if(err.notFound){
-                        curr_state = {state: "start"};
+                        data = {state: "start"};
                     }else{
                         return callback(err);
                     }
                 }
-                callback(undefined, _.has(rule.select.state_machine, curr_state.state)
-                    ? curr_state
+                callback(undefined, _.has(rule.select.state_machine, data.state)
+                    ? data
                     : {state: "start"});
             });
         },
-        putStateMachineState: function(pico_id, rule, state, callback){
+        putStateMachine: function(pico_id, rule, data, callback){
             var key = ["state_machine", pico_id, rule.rid, rule.name];
-            ldb.put(key, state, callback);
+            ldb.put(key, data, callback);
         },
 
 

--- a/packages/pico-engine-core/src/DB.js
+++ b/packages/pico-engine-core/src/DB.js
@@ -759,38 +759,19 @@ module.exports = function(opts){
             ldb.get(key, function(err, curr_state){
                 if(err){
                     if(err.notFound){
-                        curr_state = undefined;
+                        curr_state = {state: "start"};
                     }else{
                         return callback(err);
                     }
                 }
-                callback(undefined, _.has(rule.select.state_machine, curr_state)
+                callback(undefined, _.has(rule.select.state_machine, curr_state.state)
                     ? curr_state
-                    : "start");
+                    : {state: "start"});
             });
         },
         putStateMachineState: function(pico_id, rule, state, callback){
             var key = ["state_machine", pico_id, rule.rid, rule.name];
-            ldb.put(key, state || "start", callback);
-        },
-
-
-        getStateMachineStartTime: function(pico_id, rule, callback){
-            var key = ["state_machine_starttime", pico_id, rule.rid, rule.name];
-            ldb.get(key, function(err, time){
-                if(err){
-                    if(err.notFound){
-                        time = undefined;
-                    }else{
-                        return callback(err);
-                    }
-                }
-                callback(undefined, time);
-            });
-        },
-        putStateMachineStartTime: function(pico_id, rule, time, callback){
-            var key = ["state_machine_starttime", pico_id, rule.rid, rule.name];
-            ldb.put(key, time, callback);
+            ldb.put(key, state, callback);
         },
 
 

--- a/packages/pico-engine-core/src/index.test.js
+++ b/packages/pico-engine-core/src/index.test.js
@@ -371,6 +371,16 @@ test("PicoEngine - io.picolabs.events ruleset", function(t){
                 []
             ],
             [
+                // test that select() scope overrides the global scope
+                signal("events", "where_using_global", {a: "g one"}),
+                [{name: "where_using_global", options: {}}]
+            ],
+            [
+                // test that event:attr scope doesn't stomp over global
+                signal("events", "where_using_global", {a: "g one", global1: "haha! if this works the rule will not select"}),
+                [{name: "where_using_global", options: {}}]
+            ],
+            [
                 signal("events", "implicit_match_0", {something: 0}),
                 [{name: "implicit_match_0", options: {}}]
             ],

--- a/packages/pico-engine-core/src/index.test.js
+++ b/packages/pico-engine-core/src/index.test.js
@@ -381,6 +381,11 @@ test("PicoEngine - io.picolabs.events ruleset", function(t){
                 [{name: "where_using_global", options: {}}]
             ],
             [
+                // test that event:attr scope doesn't stomp over setting()
+                signal("events", "where_using_global", {a: "g one", global0: "haha! if this works the rule will not select"}),
+                [{name: "where_using_global", options: {}}]
+            ],
+            [
                 signal("events", "implicit_match_0", {something: 0}),
                 [{name: "implicit_match_0", options: {}}]
             ],

--- a/packages/pico-engine-core/src/index.test.js
+++ b/packages/pico-engine-core/src/index.test.js
@@ -464,12 +464,36 @@ test("PicoEngine - io.picolabs.scope ruleset", function(t){
                 signal("scope", "eventOr0", {}),
                 [{name: "eventOr", options: {name0: "", name1: void 0}}]
             ],
+            [
+                signal("scope", "eventOr1", {name: "?"}),
+                [{name: "eventOr", options: {name0: void 0, name1: "?"}}]
+            ],
 
             // setting() variables should be persisted until the rule fires
             [signal("scope", "eventAnd0", {name: "000"}), []],
             [
                 signal("scope", "eventAnd1", {name: "111"}),
                 [{name: "eventAnd", options: {name0: "000", name1: "111"}}]
+            ],
+
+
+            // setting() variables should be persisted until the rule fires or time runs out
+            [signal("scope", "eventWithin1", {name: "111"}, new Date(10000000000000)), []],
+            [
+                signal("scope", "eventWithin2", {name: "222"}, new Date(10000000000007)),
+                [{name: "eventWithin", options: {name1: "111", name2: "222"}}]
+            ],
+            // now let too much time pass for it to remember 111
+            [signal("scope", "eventWithin1", {name: "111"}, new Date(10000000000000)), []],
+            [signal("scope", "eventWithin0", {}, new Date(10000000007000)), []],
+            [
+                signal("scope", "eventWithin2", {name: "222"}, new Date(10000000007007)),
+                [{name: "eventWithin", options: {name1: void 0, name2: "222"}}]
+            ],
+            [signal("scope", "eventWithin1", {name: "aaa"}, new Date(10000000007008)), []],
+            [
+                signal("scope", "eventWithin3", {}, new Date(10000000007009)),
+                [{name: "eventWithin", options: {name1: "aaa", name2: void 0}}]
             ],
 
             // Testing the scope of the prelude block

--- a/packages/pico-engine-core/src/index.test.js
+++ b/packages/pico-engine-core/src/index.test.js
@@ -450,18 +450,29 @@ test("PicoEngine - io.picolabs.scope ruleset", function(t){
         var signal = mkSignalTask(pe, "id1");
 
         testOutputs(t, [
+
+            // Testing how setting() variables work on `or`
             [
-                signal("scope", "event0", {name: "name 0"}),
-                [{name: "say", options: {name: "name 0"}}]
+                signal("scope", "eventOr0", {name: "000"}),
+                [{name: "eventOr", options: {name0: "000", name1: void 0}}]
             ],
             [
-                signal("scope", "event1", {name: "name 1"}),
-                [{name: "say", options: {name: undefined}}]
+                signal("scope", "eventOr1", {name: "111"}),
+                [{name: "eventOr", options: {name0: void 0, name1: "111"}}]
             ],
             [
-                signal("scope", "event0", {}),
-                [{name: "say", options: {name: ""}}]
+                signal("scope", "eventOr0", {}),
+                [{name: "eventOr", options: {name0: "", name1: void 0}}]
             ],
+
+            // setting() variables should be persisted until the rule fires
+            [signal("scope", "eventAnd0", {name: "000"}), []],
+            [
+                signal("scope", "eventAnd1", {name: "111"}),
+                [{name: "eventAnd", options: {name0: "000", name1: "111"}}]
+            ],
+
+            // Testing the scope of the prelude block
             [
                 signal("scope", "prelude", {name: "Bill"}),
                 [{name: "say", options: {

--- a/packages/pico-engine-core/src/index.test.js
+++ b/packages/pico-engine-core/src/index.test.js
@@ -363,6 +363,14 @@ test("PicoEngine - io.picolabs.events ruleset", function(t){
                 [{name: "where_match_empty_str", options: {}}]
             ],
             [
+                signal("events", "where_after_setting", {a: "one"}),
+                [{name: "where_after_setting", options: {}}]
+            ],
+            [
+                signal("events", "where_after_setting", {a: "two"}),
+                []
+            ],
+            [
                 signal("events", "implicit_match_0", {something: 0}),
                 [{name: "implicit_match_0", options: {}}]
             ],

--- a/packages/pico-engine-core/src/migrations/20180222T195856_state_machine.js
+++ b/packages/pico-engine-core/src/migrations/20180222T195856_state_machine.js
@@ -1,0 +1,47 @@
+var _ = require("lodash");
+var dbRange = require("../dbRange");
+
+module.exports = {
+    up: function(ldb, callback){
+
+        var new_data = {};
+
+        dbRange(ldb, {
+            prefix: ["state_machine"],
+        }, function(data){
+            var pico_id = data.key[1];
+            var rid = data.key[2];
+            var rule_name = data.key[3];
+
+            _.set(new_data, [pico_id, rid, rule_name, "state"], data.value);
+        }, function(err){
+            if(err) return callback(err);
+
+            dbRange(ldb, {
+                prefix: ["state_machine_starttime"],
+            }, function(data){
+                var pico_id = data.key[1];
+                var rid = data.key[2];
+                var rule_name = data.key[3];
+
+                _.set(new_data, [pico_id, rid, rule_name, "starttime"], data.value);
+            }, function(err){
+                if(err) return callback(err);
+
+                var db_ops = [];
+                _.each(new_data, function(data, pico_id){
+                    _.each(data, function(data, rid){
+                        _.each(data, function(value, rule_name){
+                            db_ops.push({
+                                type: "put",
+                                key: ["state_machine", pico_id, rid, rule_name],
+                                value: value,
+                            });
+                        });
+                    });
+                });
+                ldb.batch(db_ops, callback);
+            });
+        });
+    },
+};

--- a/packages/pico-engine-core/src/migrations/20180222T195856_state_machine.js
+++ b/packages/pico-engine-core/src/migrations/20180222T195856_state_machine.js
@@ -4,6 +4,8 @@ var dbRange = require("../dbRange");
 module.exports = {
     up: function(ldb, callback){
 
+        var db_ops = [];
+
         var new_data = {};
 
         dbRange(ldb, {
@@ -25,10 +27,12 @@ module.exports = {
                 var rule_name = data.key[3];
 
                 _.set(new_data, [pico_id, rid, rule_name, "starttime"], data.value);
+
+                db_ops.push({type: "del", key: data.key});
+
             }, function(err){
                 if(err) return callback(err);
 
-                var db_ops = [];
                 _.each(new_data, function(data, pico_id){
                     _.each(data, function(data, rid){
                         _.each(data, function(value, rule_name){

--- a/packages/pico-engine-core/src/migrations/index.js
+++ b/packages/pico-engine-core/src/migrations/index.js
@@ -23,4 +23,5 @@ module.exports = {
     "20170823T213214_admin_eci": require("./20170823T213214_admin_eci"),
     "20171031T182007_pvar_index": require("./20171031T182007_pvar_index"),
     "20171117T191959_admin_policy_id": require("./20171117T191959_admin_policy_id"),
+    "20180222T195856_state_machine": require("./20180222T195856_state_machine"),
 };

--- a/test-rulesets/defaction.js
+++ b/test-rulesets/defaction.js
@@ -168,7 +168,7 @@ module.exports = {
       "select": {
         "graph": { "defa": { "foo": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -195,7 +195,7 @@ module.exports = {
       "select": {
         "graph": { "defa": { "bar": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -226,7 +226,7 @@ module.exports = {
       "select": {
         "graph": { "defa": { "bar_setting": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -260,7 +260,7 @@ module.exports = {
       "select": {
         "graph": { "defa": { "chooser": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -287,7 +287,7 @@ module.exports = {
       "select": {
         "graph": { "defa": { "ifAnotB": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -323,7 +323,7 @@ module.exports = {
       "select": {
         "graph": { "defa": { "add": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -353,7 +353,7 @@ module.exports = {
       "select": {
         "graph": { "defa": { "returns": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -406,7 +406,7 @@ module.exports = {
       "select": {
         "graph": { "defa": { "scope": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -480,7 +480,7 @@ module.exports = {
       "select": {
         "graph": { "defa": { "trying_to_use_action_as_fn": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/engine.js
+++ b/test-rulesets/engine.js
@@ -6,7 +6,7 @@ module.exports = {
       "select": {
         "graph": { "engine": { "newPico": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -33,7 +33,7 @@ module.exports = {
       "select": {
         "graph": { "engine": { "newChannel": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -67,7 +67,7 @@ module.exports = {
       "select": {
         "graph": { "engine": { "removeChannel": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -94,7 +94,7 @@ module.exports = {
       "select": {
         "graph": { "engine": { "installRuleset": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/error.js
+++ b/test-rulesets/error.js
@@ -12,7 +12,7 @@ module.exports = {
       "select": {
         "graph": { "system": { "error": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -42,7 +42,7 @@ module.exports = {
       "select": {
         "graph": { "error": { "continue_on_error": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -72,7 +72,7 @@ module.exports = {
       "select": {
         "graph": { "error": { "continue_on_error": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -102,7 +102,7 @@ module.exports = {
       "select": {
         "graph": { "error": { "stop_on_error": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -131,7 +131,7 @@ module.exports = {
       "select": {
         "graph": { "error": { "stop_on_error": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/event-exp.js
+++ b/test-rulesets/event-exp.js
@@ -11,10 +11,10 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -50,10 +50,10 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -89,10 +89,10 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -145,10 +145,10 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -194,10 +194,10 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -236,13 +236,13 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_2": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_2": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -283,13 +283,13 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_2": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_2": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -332,13 +332,13 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_2": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_2": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -389,13 +389,13 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_2": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_2": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -452,13 +452,13 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_2": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_2": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -499,13 +499,13 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_2": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_2": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -546,13 +546,13 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_2": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_2": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -611,13 +611,13 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_2": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_2": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -715,16 +715,16 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_2": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_2": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_3": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_3": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -772,16 +772,16 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_2": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_2": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_3": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_3": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -878,7 +878,7 @@ module.exports = {
       "select": {
         "graph": { "ee_count": { "a": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -913,7 +913,7 @@ module.exports = {
       "select": {
         "graph": { "ee_repeat": { "a": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -960,7 +960,7 @@ module.exports = {
       "select": {
         "graph": { "ee_count_max": { "a": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -1010,7 +1010,7 @@ module.exports = {
       "select": {
         "graph": { "ee_repeat_min": { "a": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -1064,7 +1064,7 @@ module.exports = {
       "select": {
         "graph": { "ee_repeat_sum": { "a": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -1118,7 +1118,7 @@ module.exports = {
       "select": {
         "graph": { "ee_repeat_avg": { "a": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -1172,7 +1172,7 @@ module.exports = {
       "select": {
         "graph": { "ee_repeat_push": { "a": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -1226,7 +1226,7 @@ module.exports = {
       "select": {
         "graph": { "ee_repeat_push_multi": { "a": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -1312,7 +1312,7 @@ module.exports = {
       "select": {
         "graph": { "ee_repeat_sum_multi": { "a": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;

--- a/test-rulesets/events.js
+++ b/test-rulesets/events.js
@@ -21,6 +21,8 @@ module.exports = {
     ctx.scope.set("getSentName", ctx.mkFunction([], function* (ctx, args) {
       return yield ctx.modules.get(ctx, "ent", "sent_name");
     }));
+    ctx.scope.set("global0", "g zero");
+    ctx.scope.set("global1", "g one");
   },
   "rules": {
     "set_attr": {
@@ -482,8 +484,13 @@ module.exports = {
         "graph": { "events": { "select_where": { "expr_0": true } } },
         "eventexprs": {
           "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+            var event_attrs = yield ctx.modules.get(ctx, "event", "attrs");
+            Object.keys(event_attrs).forEach(function (attr) {
+              if (!ctx.scope.has(attr))
+                ctx.scope.set(attr, event_attrs[attr]);
+            });
             if (!(yield ctx.callKRLstdlib("match", [
-                yield ctx.applyFn(yield ctx.modules.get(ctx, "event", "attr"), ctx, ["something"]),
+                ctx.scope.get("something"),
                 new RegExp("^wat", "")
               ])))
               return false;
@@ -514,8 +521,13 @@ module.exports = {
         "graph": { "events": { "where_match_0": { "expr_0": true } } },
         "eventexprs": {
           "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+            var event_attrs = yield ctx.modules.get(ctx, "event", "attrs");
+            Object.keys(event_attrs).forEach(function (attr) {
+              if (!ctx.scope.has(attr))
+                ctx.scope.set(attr, event_attrs[attr]);
+            });
             if (!(yield ctx.callKRLstdlib("match", [
-                yield ctx.applyFn(yield ctx.modules.get(ctx, "event", "attr"), ctx, ["something"]),
+                ctx.scope.get("something"),
                 new RegExp("0", "")
               ])))
               return false;
@@ -546,8 +558,13 @@ module.exports = {
         "graph": { "events": { "where_match_null": { "expr_0": true } } },
         "eventexprs": {
           "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+            var event_attrs = yield ctx.modules.get(ctx, "event", "attrs");
+            Object.keys(event_attrs).forEach(function (attr) {
+              if (!ctx.scope.has(attr))
+                ctx.scope.set(attr, event_attrs[attr]);
+            });
             if (!(yield ctx.callKRLstdlib("match", [
-                yield ctx.applyFn(yield ctx.modules.get(ctx, "event", "attr"), ctx, ["something"]),
+                ctx.scope.get("something"),
                 new RegExp("null", "")
               ])))
               return false;
@@ -578,8 +595,13 @@ module.exports = {
         "graph": { "events": { "where_match_false": { "expr_0": true } } },
         "eventexprs": {
           "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+            var event_attrs = yield ctx.modules.get(ctx, "event", "attrs");
+            Object.keys(event_attrs).forEach(function (attr) {
+              if (!ctx.scope.has(attr))
+                ctx.scope.set(attr, event_attrs[attr]);
+            });
             if (!(yield ctx.callKRLstdlib("match", [
-                yield ctx.applyFn(yield ctx.modules.get(ctx, "event", "attr"), ctx, ["something"]),
+                ctx.scope.get("something"),
                 new RegExp("false", "")
               ])))
               return false;
@@ -610,8 +632,13 @@ module.exports = {
         "graph": { "events": { "where_match_empty_str": { "expr_0": true } } },
         "eventexprs": {
           "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+            var event_attrs = yield ctx.modules.get(ctx, "event", "attrs");
+            Object.keys(event_attrs).forEach(function (attr) {
+              if (!ctx.scope.has(attr))
+                ctx.scope.set(attr, event_attrs[attr]);
+            });
             if (!(yield ctx.callKRLstdlib("match", [
-                yield ctx.applyFn(yield ctx.modules.get(ctx, "event", "attr"), ctx, ["something"]),
+                ctx.scope.get("something"),
                 new RegExp("(?:)", "")
               ])))
               return false;
@@ -642,6 +669,11 @@ module.exports = {
         "graph": { "events": { "where_after_setting": { "expr_0": true } } },
         "eventexprs": {
           "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+            var event_attrs = yield ctx.modules.get(ctx, "event", "attrs");
+            Object.keys(event_attrs).forEach(function (attr) {
+              if (!ctx.scope.has(attr))
+                ctx.scope.set(attr, event_attrs[attr]);
+            });
             var matches = [];
             var m;
             var j;
@@ -652,7 +684,7 @@ module.exports = {
               matches.push(m[j]);
             ctx.scope.set("a", matches[0]);
             if (!(yield ctx.callKRLstdlib("==", [
-                yield ctx.applyFn(yield ctx.modules.get(ctx, "event", "attr"), ctx, ["a"]),
+                ctx.scope.get("a"),
                 "one"
               ])))
               return false;
@@ -670,6 +702,52 @@ module.exports = {
         var fired = true;
         if (fired) {
           yield runAction(ctx, void 0, "send_directive", ["where_after_setting"], []);
+        }
+        if (fired)
+          ctx.emit("debug", "fired");
+        else
+          ctx.emit("debug", "not fired");
+      }
+    },
+    "where_using_global": {
+      "name": "where_using_global",
+      "select": {
+        "graph": { "events": { "where_using_global": { "expr_0": true } } },
+        "eventexprs": {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+            var event_attrs = yield ctx.modules.get(ctx, "event", "attrs");
+            Object.keys(event_attrs).forEach(function (attr) {
+              if (!ctx.scope.has(attr))
+                ctx.scope.set(attr, event_attrs[attr]);
+            });
+            var matches = [];
+            var m;
+            var j;
+            m = new RegExp("(.*)", "").exec(getAttrString(ctx, "a"));
+            if (!m)
+              return false;
+            for (j = 1; j < m.length; j++)
+              matches.push(m[j]);
+            ctx.scope.set("global0", matches[0]);
+            if (!(yield ctx.callKRLstdlib("==", [
+                ctx.scope.get("global0"),
+                ctx.scope.get("global1")
+              ])))
+              return false;
+            return true;
+          }
+        },
+        "state_machine": {
+          "start": [[
+              "expr_0",
+              "end"
+            ]]
+        }
+      },
+      "body": function* (ctx, runAction, toPairs) {
+        var fired = true;
+        if (fired) {
+          yield runAction(ctx, void 0, "send_directive", ["where_using_global"], []);
         }
         if (fired)
           ctx.emit("debug", "fired");

--- a/test-rulesets/events.js
+++ b/test-rulesets/events.js
@@ -30,7 +30,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "bind": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -39,7 +39,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("my_name", matches[0]);
+            setting("my_name", matches[0]);
             return true;
           }
         },
@@ -69,7 +69,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "set_attr2": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -83,8 +83,8 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("number", matches[0]);
-            ctx.scope.set("name", matches[1]);
+            setting("number", matches[0]);
+            setting("name", matches[1]);
             return true;
           }
         },
@@ -117,7 +117,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "get": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -148,7 +148,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "noop": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -172,7 +172,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "noop2": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -199,7 +199,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "ifthen": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -208,7 +208,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("my_name", matches[0]);
+            setting("my_name", matches[0]);
             return true;
           }
         },
@@ -235,7 +235,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "on_fired": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -244,7 +244,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("my_name", matches[0]);
+            setting("my_name", matches[0]);
             return true;
           }
         },
@@ -277,7 +277,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "on_choose": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -286,7 +286,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("thing", matches[0]);
+            setting("thing", matches[0]);
             return true;
           }
         },
@@ -326,7 +326,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "on_choose_if": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -335,7 +335,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("thing", matches[0]);
+            setting("thing", matches[0]);
             return true;
           }
         },
@@ -378,7 +378,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "on_every": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -406,7 +406,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "on_sample": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -443,7 +443,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "on_sample_if": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -483,7 +483,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "select_where": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var event_attrs = yield ctx.modules.get(ctx, "event", "attrs");
             Object.keys(event_attrs).forEach(function (attr) {
               if (!ctx.scope.has(attr))
@@ -520,7 +520,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "where_match_0": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var event_attrs = yield ctx.modules.get(ctx, "event", "attrs");
             Object.keys(event_attrs).forEach(function (attr) {
               if (!ctx.scope.has(attr))
@@ -557,7 +557,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "where_match_null": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var event_attrs = yield ctx.modules.get(ctx, "event", "attrs");
             Object.keys(event_attrs).forEach(function (attr) {
               if (!ctx.scope.has(attr))
@@ -594,7 +594,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "where_match_false": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var event_attrs = yield ctx.modules.get(ctx, "event", "attrs");
             Object.keys(event_attrs).forEach(function (attr) {
               if (!ctx.scope.has(attr))
@@ -631,7 +631,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "where_match_empty_str": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var event_attrs = yield ctx.modules.get(ctx, "event", "attrs");
             Object.keys(event_attrs).forEach(function (attr) {
               if (!ctx.scope.has(attr))
@@ -668,7 +668,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "where_after_setting": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var event_attrs = yield ctx.modules.get(ctx, "event", "attrs");
             Object.keys(event_attrs).forEach(function (attr) {
               if (!ctx.scope.has(attr))
@@ -682,7 +682,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("a", matches[0]);
+            setting("a", matches[0]);
             if (!(yield ctx.callKRLstdlib("==", [
                 ctx.scope.get("a"),
                 "one"
@@ -714,7 +714,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "where_using_global": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var event_attrs = yield ctx.modules.get(ctx, "event", "attrs");
             Object.keys(event_attrs).forEach(function (attr) {
               if (!ctx.scope.has(attr))
@@ -728,7 +728,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("global0", matches[0]);
+            setting("global0", matches[0]);
             if (!(yield ctx.callKRLstdlib("==", [
                 ctx.scope.get("global0"),
                 ctx.scope.get("global1")
@@ -760,7 +760,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "implicit_match_0": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -795,7 +795,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "implicit_match_null": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -830,7 +830,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "implicit_match_false": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -865,7 +865,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "implicit_match_empty_str": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -900,7 +900,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "no_action": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -938,7 +938,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "action_send": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -947,7 +947,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("my_name", matches[0]);
+            setting("my_name", matches[0]);
             return true;
           }
         },
@@ -980,7 +980,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "store_sent_name": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -989,7 +989,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("my_name", matches[0]);
+            setting("my_name", matches[0]);
             return true;
           }
         },
@@ -1017,7 +1017,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "raise_set_name": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -1026,7 +1026,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("my_name", matches[0]);
+            setting("my_name", matches[0]);
             return true;
           }
         },
@@ -1058,7 +1058,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "raise_set_name_attr": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -1067,7 +1067,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("my_name", matches[0]);
+            setting("my_name", matches[0]);
             return true;
           }
         },
@@ -1099,7 +1099,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "raise_set_name_rid": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -1108,7 +1108,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("my_name", matches[0]);
+            setting("my_name", matches[0]);
             return true;
           }
         },
@@ -1141,7 +1141,7 @@ module.exports = {
       "select": {
         "graph": { "events": { "event_eid": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/events.js
+++ b/test-rulesets/events.js
@@ -636,6 +636,47 @@ module.exports = {
           ctx.emit("debug", "not fired");
       }
     },
+    "where_after_setting": {
+      "name": "where_after_setting",
+      "select": {
+        "graph": { "events": { "where_after_setting": { "expr_0": true } } },
+        "eventexprs": {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+            var matches = [];
+            var m;
+            var j;
+            m = new RegExp("(.*)", "").exec(getAttrString(ctx, "a"));
+            if (!m)
+              return false;
+            for (j = 1; j < m.length; j++)
+              matches.push(m[j]);
+            ctx.scope.set("a", matches[0]);
+            if (!(yield ctx.callKRLstdlib("==", [
+                yield ctx.applyFn(yield ctx.modules.get(ctx, "event", "attr"), ctx, ["a"]),
+                "one"
+              ])))
+              return false;
+            return true;
+          }
+        },
+        "state_machine": {
+          "start": [[
+              "expr_0",
+              "end"
+            ]]
+        }
+      },
+      "body": function* (ctx, runAction, toPairs) {
+        var fired = true;
+        if (fired) {
+          yield runAction(ctx, void 0, "send_directive", ["where_after_setting"], []);
+        }
+        if (fired)
+          ctx.emit("debug", "fired");
+        else
+          ctx.emit("debug", "not fired");
+      }
+    },
     "implicit_match_0": {
       "name": "implicit_match_0",
       "select": {

--- a/test-rulesets/events.js
+++ b/test-rulesets/events.js
@@ -638,7 +638,7 @@ module.exports = {
                 ctx.scope.set(attr, event_attrs[attr]);
             });
             if (!(yield ctx.callKRLstdlib("match", [
-                ctx.scope.get("something"),
+                yield ctx.applyFn(yield ctx.modules.get(ctx, "event", "attr"), ctx, ["something"]),
                 new RegExp("(?:)", "")
               ])))
               return false;

--- a/test-rulesets/events.krl
+++ b/test-rulesets/events.krl
@@ -156,6 +156,11 @@ ruleset io.picolabs.events {
 
         send_directive("where_match_empty_str");
     }
+    rule where_after_setting {
+        select when events where_after_setting a re#(.*)# setting(a) where a == "one"
+
+        send_directive("where_after_setting");
+    }
     rule implicit_match_0 {
         select when events implicit_match_0 something re#0#
 

--- a/test-rulesets/events.krl
+++ b/test-rulesets/events.krl
@@ -15,6 +15,8 @@ ruleset io.picolabs.events {
         getSentName = function(){
             ent:sent_name;
         }
+        global0 = "g zero"
+        global1 = "g one"
     }
     rule set_attr {
         select when events bind name re#^(.*)$# setting(my_name)
@@ -160,6 +162,11 @@ ruleset io.picolabs.events {
         select when events where_after_setting a re#(.*)# setting(a) where a == "one"
 
         send_directive("where_after_setting");
+    }
+    rule where_using_global {
+        select when events where_using_global a re#(.*)# setting(global0) where global0 == global1
+
+        send_directive("where_using_global");
     }
     rule implicit_match_0 {
         select when events implicit_match_0 something re#0#

--- a/test-rulesets/events.krl
+++ b/test-rulesets/events.krl
@@ -154,7 +154,7 @@ ruleset io.picolabs.events {
         send_directive("where_match_false");
     }
     rule where_match_empty_str {
-        select when events where_match_empty_str where something.match(re##)
+        select when events where_match_empty_str where event:attr("something").match(re##)
 
         send_directive("where_match_empty_str");
     }

--- a/test-rulesets/execution-order.js
+++ b/test-rulesets/execution-order.js
@@ -12,7 +12,7 @@ module.exports = {
       "select": {
         "graph": { "execution_order": { "all": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -49,7 +49,7 @@ module.exports = {
       "select": {
         "graph": { "execution_order": { "all": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -86,7 +86,7 @@ module.exports = {
       "select": {
         "graph": { "execution_order": { "reset_order": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -119,10 +119,10 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -159,7 +159,7 @@ module.exports = {
       "select": {
         "graph": { "execution_order": { "foo": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -190,7 +190,7 @@ module.exports = {
       "select": {
         "graph": { "execution_order": { "bar": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/execution-order2.js
+++ b/test-rulesets/execution-order2.js
@@ -12,7 +12,7 @@ module.exports = {
       "select": {
         "graph": { "execution_order": { "reset_order": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -45,10 +45,10 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -85,7 +85,7 @@ module.exports = {
       "select": {
         "graph": { "execution_order": { "foo": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -116,7 +116,7 @@ module.exports = {
       "select": {
         "graph": { "execution_order": { "bar": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/foreach.js
+++ b/test-rulesets/foreach.js
@@ -16,7 +16,7 @@ module.exports = {
       "select": {
         "graph": { "foreach": { "basic": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -57,7 +57,7 @@ module.exports = {
       "select": {
         "graph": { "foreach": { "map": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -102,7 +102,7 @@ module.exports = {
       "select": {
         "graph": { "foreach": { "nested": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -156,7 +156,7 @@ module.exports = {
       "select": {
         "graph": { "foreach": { "scope": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -220,7 +220,7 @@ module.exports = {
       "select": {
         "graph": { "foreach": { "final": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -282,7 +282,7 @@ module.exports = {
       "select": {
         "graph": { "foreach": { "final_raised": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/guard-conditions.js
+++ b/test-rulesets/guard-conditions.js
@@ -12,7 +12,7 @@ module.exports = {
       "select": {
         "graph": { "foo": { "a": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -21,7 +21,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("b", matches[0]);
+            setting("b", matches[0]);
             return true;
           }
         },
@@ -56,7 +56,7 @@ module.exports = {
       "select": {
         "graph": { "bar": { "a": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -102,7 +102,7 @@ module.exports = {
       "select": {
         "graph": { "on_final_no_foreach": { "a": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/hello-world.js
+++ b/test-rulesets/hello-world.js
@@ -23,7 +23,7 @@ module.exports = {
       "select": {
         "graph": { "echo": { "hello": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/http.js
+++ b/test-rulesets/http.js
@@ -76,7 +76,7 @@ module.exports = {
       "select": {
         "graph": { "http_test": { "get": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -109,7 +109,7 @@ module.exports = {
       "select": {
         "graph": { "http_test": { "post": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -153,7 +153,7 @@ module.exports = {
       "select": {
         "graph": { "http_test": { "post_action": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -185,7 +185,7 @@ module.exports = {
       "select": {
         "graph": { "http_test": { "post_setting": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -220,7 +220,7 @@ module.exports = {
       "select": {
         "graph": { "http_test": { "autoraise": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -253,7 +253,7 @@ module.exports = {
       "select": {
         "graph": { "http": { "post": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/js-module.js
+++ b/test-rulesets/js-module.js
@@ -16,7 +16,7 @@ module.exports = {
       "select": {
         "graph": { "js_module": { "action": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/key-used.js
+++ b/test-rulesets/key-used.js
@@ -67,7 +67,7 @@ module.exports = {
       "select": {
         "graph": { "key_used": { "foo": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/last.js
+++ b/test-rulesets/last.js
@@ -7,7 +7,7 @@ module.exports = {
       "select": {
         "graph": { "last": { "all": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -41,7 +41,7 @@ module.exports = {
       "select": {
         "graph": { "last": { "all": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -75,7 +75,7 @@ module.exports = {
       "select": {
         "graph": { "last": { "all": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -105,7 +105,7 @@ module.exports = {
       "select": {
         "graph": { "last": { "all": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/log.js
+++ b/test-rulesets/log.js
@@ -6,7 +6,7 @@ module.exports = {
       "select": {
         "graph": { "log": { "levels": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/meta.js
+++ b/test-rulesets/meta.js
@@ -28,7 +28,7 @@ module.exports = {
       "select": {
         "graph": { "meta": { "event": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/module-defined.js
+++ b/test-rulesets/module-defined.js
@@ -56,7 +56,7 @@ module.exports = {
       "select": {
         "graph": { "module_defined": { "store_memo": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -65,7 +65,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("text", matches[0]);
+            setting("text", matches[0]);
             return true;
           }
         },

--- a/test-rulesets/module-used.js
+++ b/test-rulesets/module-used.js
@@ -37,7 +37,7 @@ module.exports = {
       "select": {
         "graph": { "module_used": { "dflt_name": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -67,7 +67,7 @@ module.exports = {
       "select": {
         "graph": { "module_used": { "conf_name": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -97,7 +97,7 @@ module.exports = {
       "select": {
         "graph": { "module_used": { "dflt_info": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -127,7 +127,7 @@ module.exports = {
       "select": {
         "graph": { "module_used": { "conf_info": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -157,7 +157,7 @@ module.exports = {
       "select": {
         "graph": { "module_used": { "dflt_getInfoAction": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -185,7 +185,7 @@ module.exports = {
       "select": {
         "graph": { "module_used": { "conf_getInfoAction": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/persistent-index.js
+++ b/test-rulesets/persistent-index.js
@@ -36,7 +36,7 @@ module.exports = {
       "select": {
         "graph": { "pindex": { "setfoo": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -61,7 +61,7 @@ module.exports = {
       "select": {
         "graph": { "pindex": { "putfoo": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -91,7 +91,7 @@ module.exports = {
       "select": {
         "graph": { "pindex": { "delfoo": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -120,7 +120,7 @@ module.exports = {
       "select": {
         "graph": { "pindex": { "nukefoo": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -145,7 +145,7 @@ module.exports = {
       "select": {
         "graph": { "pindex": { "setbar": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -170,7 +170,7 @@ module.exports = {
       "select": {
         "graph": { "pindex": { "putbar": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -200,7 +200,7 @@ module.exports = {
       "select": {
         "graph": { "pindex": { "delbar": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -229,7 +229,7 @@ module.exports = {
       "select": {
         "graph": { "pindex": { "nukebar": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/persistent.js
+++ b/test-rulesets/persistent.js
@@ -31,7 +31,7 @@ module.exports = {
       "select": {
         "graph": { "store": { "name": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -40,7 +40,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("my_name", matches[0]);
+            setting("my_name", matches[0]);
             return true;
           }
         },
@@ -71,7 +71,7 @@ module.exports = {
       "select": {
         "graph": { "store": { "appvar": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -80,7 +80,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("my_appvar", matches[0]);
+            setting("my_appvar", matches[0]);
             return true;
           }
         },
@@ -111,7 +111,7 @@ module.exports = {
       "select": {
         "graph": { "store": { "user_firstname": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -120,7 +120,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("firstname", matches[0]);
+            setting("firstname", matches[0]);
             return true;
           }
         },
@@ -155,7 +155,7 @@ module.exports = {
       "select": {
         "graph": { "store": { "clear_user": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -183,7 +183,7 @@ module.exports = {
       "select": {
         "graph": { "store": { "clear_appvar": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/policies.js
+++ b/test-rulesets/policies.js
@@ -18,7 +18,7 @@ module.exports = {
       "select": {
         "graph": { "policies": { "foo": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -42,7 +42,7 @@ module.exports = {
       "select": {
         "graph": { "policies": { "bar": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -66,7 +66,7 @@ module.exports = {
       "select": {
         "graph": { "policies": { "baz": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -90,7 +90,7 @@ module.exports = {
       "select": {
         "graph": { "other": { "foo": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -114,7 +114,7 @@ module.exports = {
       "select": {
         "graph": { "other": { "bar": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -138,7 +138,7 @@ module.exports = {
       "select": {
         "graph": { "other": { "baz": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/schedule.js
+++ b/test-rulesets/schedule.js
@@ -20,7 +20,7 @@ module.exports = {
       "select": {
         "graph": { "schedule": { "clear_log": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -50,7 +50,7 @@ module.exports = {
       "select": {
         "graph": { "schedule": { "push_log": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -83,7 +83,7 @@ module.exports = {
       "select": {
         "graph": { "schedule": { "in_5min": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -128,7 +128,7 @@ module.exports = {
       "select": {
         "graph": { "schedule": { "every_1min": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -170,7 +170,7 @@ module.exports = {
       "select": {
         "graph": { "schedule": { "rm_from_schedule": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/scope.js
+++ b/test-rulesets/scope.js
@@ -66,13 +66,13 @@ module.exports = {
     ]));
   },
   "rules": {
-    "eventex": {
-      "name": "eventex",
+    "eventOr": {
+      "name": "eventOr",
       "select": {
         "graph": {
           "scope": {
-            "event0": { "expr_0": true },
-            "event1": { "expr_1": true }
+            "eventOr0": { "expr_0": true },
+            "eventOr1": { "expr_1": true }
           }
         },
         "eventexprs": {
@@ -85,10 +85,19 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("my_name", matches[0]);
+            ctx.scope.set("name0", matches[0]);
             return true;
           },
           "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+            var matches = [];
+            var m;
+            var j;
+            m = new RegExp("^(.*)$", "").exec(getAttrString(ctx, "name"));
+            if (!m)
+              return false;
+            for (j = 1; j < m.length; j++)
+              matches.push(m[j]);
+            ctx.scope.set("name1", matches[0]);
             return true;
           }
         },
@@ -109,8 +118,84 @@ module.exports = {
         var fired = true;
         if (fired) {
           yield runAction(ctx, void 0, "send_directive", [
-            "say",
-            { "name": ctx.scope.get("my_name") }
+            "eventOr",
+            {
+              "name0": ctx.scope.get("name0"),
+              "name1": ctx.scope.get("name1")
+            }
+          ], []);
+        }
+        if (fired)
+          ctx.emit("debug", "fired");
+        else
+          ctx.emit("debug", "not fired");
+      }
+    },
+    "eventAnd": {
+      "name": "eventAnd",
+      "select": {
+        "graph": {
+          "scope": {
+            "eventAnd0": { "expr_0": true },
+            "eventAnd1": { "expr_1": true }
+          }
+        },
+        "eventexprs": {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+            var matches = [];
+            var m;
+            var j;
+            m = new RegExp("^(.*)$", "").exec(getAttrString(ctx, "name"));
+            if (!m)
+              return false;
+            for (j = 1; j < m.length; j++)
+              matches.push(m[j]);
+            ctx.scope.set("name0", matches[0]);
+            return true;
+          },
+          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+            var matches = [];
+            var m;
+            var j;
+            m = new RegExp("^(.*)$", "").exec(getAttrString(ctx, "name"));
+            if (!m)
+              return false;
+            for (j = 1; j < m.length; j++)
+              matches.push(m[j]);
+            ctx.scope.set("name1", matches[0]);
+            return true;
+          }
+        },
+        "state_machine": {
+          "start": [
+            [
+              "expr_0",
+              "s0"
+            ],
+            [
+              "expr_1",
+              "s1"
+            ]
+          ],
+          "s0": [[
+              "expr_1",
+              "end"
+            ]],
+          "s1": [[
+              "expr_0",
+              "end"
+            ]]
+        }
+      },
+      "body": function* (ctx, runAction, toPairs) {
+        var fired = true;
+        if (fired) {
+          yield runAction(ctx, void 0, "send_directive", [
+            "eventAnd",
+            {
+              "name0": ctx.scope.get("name0"),
+              "name1": ctx.scope.get("name1")
+            }
           ], []);
         }
         if (fired)

--- a/test-rulesets/scope.js
+++ b/test-rulesets/scope.js
@@ -76,7 +76,7 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -85,10 +85,10 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("name0", matches[0]);
+            setting("name0", matches[0]);
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -97,7 +97,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("name1", matches[0]);
+            setting("name1", matches[0]);
             return true;
           }
         },
@@ -141,7 +141,7 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -150,10 +150,10 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("name0", matches[0]);
+            setting("name0", matches[0]);
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -162,7 +162,7 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("name1", matches[0]);
+            setting("name1", matches[0]);
             return true;
           }
         },
@@ -204,12 +204,22 @@ module.exports = {
           ctx.emit("debug", "not fired");
       }
     },
-    "prelude_scope": {
-      "name": "prelude_scope",
+    "eventWithin": {
+      "name": "eventWithin",
       "select": {
-        "graph": { "scope": { "prelude": { "expr_0": true } } },
+        "graph": {
+          "scope": {
+            "eventWithin0": { "expr_0": true },
+            "eventWithin1": { "expr_1": true },
+            "eventWithin2": { "expr_2": true },
+            "eventWithin3": { "expr_3": true }
+          }
+        },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
+            return true;
+          },
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;
@@ -218,7 +228,101 @@ module.exports = {
               return false;
             for (j = 1; j < m.length; j++)
               matches.push(m[j]);
-            ctx.scope.set("name", matches[0]);
+            setting("name1", matches[0]);
+            return true;
+          },
+          "expr_2": function* (ctx, aggregateEvent, getAttrString, setting) {
+            var matches = [];
+            var m;
+            var j;
+            m = new RegExp("^(.*)$", "").exec(getAttrString(ctx, "name"));
+            if (!m)
+              return false;
+            for (j = 1; j < m.length; j++)
+              matches.push(m[j]);
+            setting("name2", matches[0]);
+            return true;
+          },
+          "expr_3": function* (ctx, aggregateEvent, getAttrString, setting) {
+            return true;
+          }
+        },
+        "state_machine": {
+          "start": [
+            [
+              "expr_0",
+              "s0"
+            ],
+            [
+              "expr_1",
+              "s0"
+            ],
+            [
+              "expr_2",
+              "s1"
+            ],
+            [
+              "expr_3",
+              "s1"
+            ]
+          ],
+          "s0": [
+            [
+              "expr_2",
+              "end"
+            ],
+            [
+              "expr_3",
+              "end"
+            ]
+          ],
+          "s1": [
+            [
+              "expr_0",
+              "end"
+            ],
+            [
+              "expr_1",
+              "end"
+            ]
+          ]
+        },
+        "within": function* (ctx) {
+          return 1 * 1000;
+        }
+      },
+      "body": function* (ctx, runAction, toPairs) {
+        var fired = true;
+        if (fired) {
+          yield runAction(ctx, void 0, "send_directive", [
+            "eventWithin",
+            {
+              "name1": ctx.scope.get("name1"),
+              "name2": ctx.scope.get("name2")
+            }
+          ], []);
+        }
+        if (fired)
+          ctx.emit("debug", "fired");
+        else
+          ctx.emit("debug", "not fired");
+      }
+    },
+    "prelude_scope": {
+      "name": "prelude_scope",
+      "select": {
+        "graph": { "scope": { "prelude": { "expr_0": true } } },
+        "eventexprs": {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
+            var matches = [];
+            var m;
+            var j;
+            m = new RegExp("^(.*)$", "").exec(getAttrString(ctx, "name"));
+            if (!m)
+              return false;
+            for (j = 1; j < m.length; j++)
+              matches.push(m[j]);
+            setting("name", matches[0]);
             return true;
           }
         },
@@ -258,7 +362,7 @@ module.exports = {
       "select": {
         "graph": { "scope": { "functions": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },

--- a/test-rulesets/scope.krl
+++ b/test-rulesets/scope.krl
@@ -28,12 +28,25 @@ ruleset io.picolabs.scope {
             n + g1;
         })
     }
-    rule eventex {
-        select when scope event0 name re#^(.*)$# setting(my_name)
+    rule eventOr {
+        select when scope eventOr0 name re#^(.*)$# setting(name0)
             or
-            scope event1
+            scope eventOr1 name re#^(.*)$# setting(name1)
 
-        send_directive("say", {"name": my_name});
+        send_directive("eventOr", {
+            "name0": name0,
+            "name1": name1
+        });
+    }
+    rule eventAnd {
+        select when scope eventAnd0 name re#^(.*)$# setting(name0)
+            and
+            scope eventAnd1 name re#^(.*)$# setting(name1)
+
+        send_directive("eventAnd", {
+            "name0": name0,
+            "name1": name1
+        });
     }
     rule prelude_scope {
         select when scope prelude name re#^(.*)$# setting(name)

--- a/test-rulesets/scope.krl
+++ b/test-rulesets/scope.krl
@@ -48,6 +48,25 @@ ruleset io.picolabs.scope {
             "name1": name1
         });
     }
+    rule eventWithin {
+        select when (
+                scope eventWithin0
+                or
+                scope eventWithin1 name re#^(.*)$# setting(name1)
+            )
+            and
+            (
+                scope eventWithin2 name re#^(.*)$# setting(name2)
+                or
+                scope eventWithin3
+            )
+            within 1 second
+
+        send_directive("eventWithin", {
+            "name1": name1,
+            "name2": name2
+        });
+    }
     rule prelude_scope {
         select when scope prelude name re#^(.*)$# setting(name)
 

--- a/test-rulesets/within.js
+++ b/test-rulesets/within.js
@@ -11,10 +11,10 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -53,10 +53,10 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -99,13 +99,13 @@ module.exports = {
           }
         },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_1": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_1": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           },
-          "expr_2": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_2": function* (ctx, aggregateEvent, getAttrString, setting) {
             return true;
           }
         },
@@ -153,7 +153,7 @@ module.exports = {
       "select": {
         "graph": { "qux": { "a": { "expr_0": true } } },
         "eventexprs": {
-          "expr_0": function* (ctx, aggregateEvent, getAttrString) {
+          "expr_0": function* (ctx, aggregateEvent, getAttrString, setting) {
             var matches = [];
             var m;
             var j;


### PR DESCRIPTION
This fixes #358 and #359

Syntax change
 `select when ... where .. setting() ` to `select when ... setting() where ..`
It's backwards comparable and emits a deprecation warning.

The variables in `setting()` are now available in `where`

The values in the global scope are now available in `where`. For backwards compatibility, `where` still lets you access event attributes as bare words.


