### PR TITLE
event:send signal the event right away, don't wait for the rules to complete

### DIFF
--- a/packages/pico-engine-core/src/modules/event.js
+++ b/packages/pico-engine-core/src/modules/event.js
@@ -39,9 +39,7 @@ module.exports = function(core){
                 callback();
                 return;
             }
-            ctx.addActionResponse(ctx, "event:send", {
-                event: event,
-            });
+            core.signalEvent(event);
             callback();
         }),
     };

--- a/packages/pico-engine-core/src/processEvent.js
+++ b/packages/pico-engine-core/src/processEvent.js
@@ -63,12 +63,6 @@ var toResponse = function(ctx, type, val){
             }
         };
     }
-    if(type === "event:send"){
-        return {
-            type: "event:send",
-            event: val.event,
-        };
-    }
     throw new Error("Unsupported action response type: " + type);
 };
 
@@ -205,14 +199,6 @@ var processEvent = cocb.wrap(function*(core, ctx){
         }
         return responses;
     });
-
-    //handle event:send() actions
-    if(_.has(r, "event:send")){
-        _.each(r["event:send"], function(o){
-            core.signalEvent(o.event);
-        });
-        delete r["event:send"];
-    }
 
 
     if(_.has(r, "directive")){


### PR DESCRIPTION
`event:send` was implemented to wait until the all the rules finish before signaling the event. I can't remember a good reason why it behaved that way. Perhaps it's a hold-over before the pico-queue was implemented.

This PR changes `event:send` to signal the event right away. (i.e. add the event to the end of the pico-queue before finishing the postlude)