### PR TITLE
engine:*  functions return null when an id is not found - fixes #399

### DIFF
--- a/packages/pico-engine-core/src/modules/engine.js
+++ b/packages/pico-engine-core/src/modules/engine.js
@@ -42,7 +42,11 @@ module.exports = function(core){
                 return callback(new TypeError("engine:getPicoIDByECI was given " + ktypes.toString(args.eci) + " instead of an eci string"));
             }
 
-            core.db.getPicoIDByECI(args.eci, callback);
+            core.db.getPicoIDByECI(args.eci, function(err, pico){
+                if(err && err.notFound) return callback();
+                if(err) return callback(err);
+                callback(null, pico);
+            });
         }),
 
 
@@ -53,9 +57,14 @@ module.exports = function(core){
             var pico_id = picoArgOrCtxPico("getParent", ctx, args);
 
             core.db.assertPicoID(pico_id, function(err, pico_id){
+                if(err && err.notFound) return callback();
                 if(err) return callback(err);
 
-                core.db.getParent(pico_id, callback);
+                core.db.getParent(pico_id, function(err, parent_id){
+                    if(err && err.notFound) return callback();
+                    if(err) return callback(err);
+                    callback(null, parent_id);
+                });
             });
         }),
 
@@ -67,9 +76,14 @@ module.exports = function(core){
             var pico_id = picoArgOrCtxPico("getAdminECI", ctx, args);
 
             core.db.assertPicoID(pico_id, function(err, pico_id){
+                if(err && err.notFound) return callback();
                 if(err) return callback(err);
 
-                core.db.getAdminECI(pico_id, callback);
+                core.db.getAdminECI(pico_id, function(err, eci){
+                    if(err && err.notFound) return callback();
+                    if(err) return callback(err);
+                    callback(null, eci);
+                });
             });
         }),
 
@@ -81,9 +95,14 @@ module.exports = function(core){
             var pico_id = picoArgOrCtxPico("listChildren", ctx, args);
 
             core.db.assertPicoID(pico_id, function(err, pico_id){
+                if(err && err.notFound) return callback();
                 if(err) return callback(err);
 
-                core.db.listChildren(pico_id, callback);
+                core.db.listChildren(pico_id, function(err, children){
+                    if(err && err.notFound) return callback();
+                    if(err) return callback(err);
+                    callback(null, children);
+                });
             });
         }),
 
@@ -101,6 +120,7 @@ module.exports = function(core){
             var pico_id = picoArgOrCtxPico("listChannels", ctx, args);
 
             core.db.assertPicoID(pico_id, function(err, pico_id){
+                if(err && err.notFound) return callback();
                 if(err) return callback(err);
 
                 core.db.listChannels(pico_id, callback);
@@ -115,9 +135,11 @@ module.exports = function(core){
             var pico_id = picoArgOrCtxPico("listInstalledRIDs", ctx, args);
 
             core.db.assertPicoID(pico_id, function(err, pico_id){
+                if(err && err.notFound) return callback();
                 if(err) return callback(err);
 
                 core.db.ridsOnPico(pico_id, function(err, rid_set){
+                    if(err && err.notFound) return callback();
                     if(err) return callback(err);
                     callback(null, _.keys(rid_set));
                 });
@@ -143,6 +165,7 @@ module.exports = function(core){
             }
 
             core.db.getEnabledRuleset(args.rid, function(err, data){
+                if(err && err.notFound) return callback();
                 if(err) return callback(err);
                 var rid = data.rid;
                 callback(null, {

--- a/packages/pico-engine-core/src/modules/engine.test.js
+++ b/packages/pico-engine-core/src/modules/engine.test.js
@@ -75,11 +75,7 @@ testPE("engine:getPicoIDByECI", function*(t, pe){
         "TypeError: engine:getPicoIDByECI was given null instead of an eci string",
         "wrong eci type"
     );
-    yield tstErr(
-        get("quux"),
-        "NotFoundError: ECI not found: quux",
-        "eci not found"
-    );
+    t.equals(yield get("quux"), void 0, "eci not found");
 });
 
 
@@ -312,12 +308,8 @@ testPE("engine:describeRuleset", function * (t, pe){
         "TypeError: engine:describeRuleset was given [Array] instead of a rid string",
         "wrong rid type"
     );
-    try{
-        yield descRID(ctx, {rid: "not.found"});
-        t.fail("should fail b/c not found");
-    }catch(err){
-        t.ok(err && err.notFound);
-    }
+
+    t.equals(yield descRID(ctx, {rid: "not.found"}), void 0);
 });
 
 
@@ -407,9 +399,9 @@ testPE("engine:getParent, engine:getAdminECI, engine:listChildren, engine:remove
     yield assertInvalidPicoID(newPico     , void 0, "TypeError: engine:newPico was given null instead of a parent_id string");
     yield assertInvalidPicoID(removePico  , void 0, "TypeError: engine:removePico was given null instead of a pico_id string");
 
-    yield assertInvalidPicoID(getAdminECI , "id404", "NotFoundError: Pico not found: id404");
-    yield assertInvalidPicoID(getParent   , "id404", "NotFoundError: Pico not found: id404");
-    yield assertInvalidPicoID(listChildren, "id404", "NotFoundError: Pico not found: id404");
+    t.equals(yield getAdminECI({}, ["id404"]), void 0);
+    t.equals(yield getParent({pico_id: "id404"}, []), void 0);
+    t.equals(yield listChildren({pico_id: "id404"}, []), void 0);
     yield assertInvalidPicoID(newPico     , "id404", "NotFoundError: Pico not found: id404");
     yield assertInvalidPicoID(removePico  , "id404", "NotFoundError: Pico not found: id404");
 
@@ -571,7 +563,7 @@ testPE("engine:newChannel, engine:listChannels, engine:removeChannel", function 
     yield assertInvalidPicoID(listChannels, void 0, "TypeError: engine:listChannels was given null instead of a pico_id string");
 
     yield assertInvalidPicoID(newChannel  , "id404", "NotFoundError: Pico not found: id404");
-    yield assertInvalidPicoID(listChannels, "id404", "NotFoundError: Pico not found: id404");
+    t.deepEquals(yield listChannels({}, ["id404"]), void 0);
 
 
     //setting policy_id on a newChannel
@@ -658,7 +650,7 @@ testPE("engine:installRuleset, engine:listInstalledRIDs, engine:uninstallRuleset
 
     yield assertInvalidPicoID(installRS   , "id404", "NotFoundError: Pico not found: id404");
     yield assertInvalidPicoID(uninstallRID, "id404", "NotFoundError: Pico not found: id404");
-    yield assertInvalidPicoID(listRIDs    , "id404", "NotFoundError: Pico not found: id404");
+    t.deepEquals(yield listRIDs({pico_id: "id404"}, []), void 0);
 
 });
 


### PR DESCRIPTION
The following functions now return `null` instead of throwing an error when the `pico_id` is not found.
`engine:getPicoIDByECI(pico_id)`
`engine:getParent(pico_id)`
`engine:getAdminECI(pico_id)`
`engine:listChildren(pico_id)`
`engine:listChannels(pico_id)`
`engine:listInstalledRIDs(pico_id)`
`engine:describeRuleset(rid)`

Actions will still throw when an id is invalid.