### PR TITLE
Install Rulesets Validation

### DIFF
--- a/packages/pico-engine/krl/io.picolabs.wrangler.krl
+++ b/packages/pico-engine/krl/io.picolabs.wrangler.krl
@@ -32,7 +32,7 @@ ruleset io.picolabs.wrangler {
                               { "domain": "wrangler", "type": "child_deletion",
                                 "attrs": [ "pico_name" ] },
                               { "domain": "wrangler", "type": "channel_creation_requested",
-                                "attrs": [ "channel_name", "channel_type" ] },
+                                "attrs": [ "name", "type" ] },
                               { "domain": "wrangler", "type": "channel_deletion_requested",
                                 "attrs": [ "eci" ] },
                               { "domain": "wrangler", "type": "install_rulesets_requested",
@@ -273,8 +273,8 @@ ruleset io.picolabs.wrangler {
         engine:newChannel(meta:picoId, name, "children") setting(parent_channel);// new eci for parent to child
         engine:newPico() setting(child);// newpico
         engine:newChannel(child{"id"}, "main", "wrangler"/*"secret"*/) setting(channel);// new child root eci
-        engine:installRuleset(child{"id"},rids.append(config{"os_rids"}));// install child OS
-        event:send( // intoroduce child to itself and parent
+        engine:installRuleset(child{"id"},config{"os_rids"});// install child OS
+        event:send( // introduce child to itself and parent
           { "eci": channel{"id"},
             "domain": "wrangler", "type": "child_created",
             "attrs": ({
@@ -282,18 +282,10 @@ ruleset io.picolabs.wrangler {
              "name": name,
              "id" : child{"id"},
              "eci": channel{"id"},
-             "rids": rids,
+             "rids_to_install": rids,
              "rs_attrs":event:attrs
             })
             });
-        event:send( // tell child that a ruleset was added
-          { "eci": channel{"id"},
-            "domain": "wrangler", "type": "ruleset_added",
-            "attrs": ({
-             "rids": rids,
-             "rs_attrs":event:attrs
-            })
-          });
       }
       returns {
        "parent_eci": parent_channel{"id"},
@@ -351,17 +343,34 @@ ruleset io.picolabs.wrangler {
     pre {
       rids = event:attr("rids").defaultsTo(event:attr("rid")).defaultsTo("")
       rid_list = (rids.typeof() ==  "Array") => rids | rids.split(re#;#)
+      valid_rids = rid_list.intersection(registeredRulesets())
+      invalid_rids = rid_list.difference(valid_rids)
+      initial_install = event:attr("init").defaultsTo(false) // if this is a new pico
     }
-    if(rids !=  "") then every{ // should we be valid checking?
-      installRulesets(rid_list) setting(rids)
-      send_directive("rulesets installed", { "rids": rid_list }); // should we return rids or rid_list?
+    if(rids !=  "") && valid_rids.length() > 0 then every{
+      installRulesets(valid_rids) setting(rids)
+      send_directive("rulesets installed", { "rids": rids{"rids"} });
     }
     fired {
       raise wrangler event "ruleset_added"
-        attributes event:attrs.put({"rids": rid_list});
+        attributes event:attrs.put(["rids"], rids{"rids"});
     }
     else {
-      error info "could not install rids, no rids attribute provide.";
+      error info "could not install rids, no rids attribute provided.";
+    }
+    finally {
+      raise wrangler event "install_ruleset_error"
+        attributes event:attrs.put(["rids"],invalid_rids) if invalid_rids.length() > 0;
+      raise wrangler event "finish_initialization"
+        attributes event:attrs  if initial_install == true;
+      
+    }
+  }
+  
+  rule installRulesetFailure {
+    select when wrangler install_ruleset_error
+    always{
+      error info "could not install rids because they do not exist: " + event:attr("rids").join(", ")
     }
   }
 
@@ -425,6 +434,7 @@ ruleset io.picolabs.wrangler {
       uniqueName = uniquePicoName(name)
       rids = event:attr("rids").defaultsTo([]);
       _rids = (rids.typeof() == "Array" => rids | rids.split(re#;#))
+
     }
     if(uniqueName) then every {
       createPico(name,_rids) setting(child)
@@ -436,6 +446,7 @@ ruleset io.picolabs.wrangler {
       ent:children := children();
       raise wrangler event "new_child_created"
         attributes child.put("rs_attrs",event:attrs);
+      
     }
     else{
       raise wrangler event "child_creation_falure"
@@ -451,8 +462,25 @@ ruleset io.picolabs.wrangler {
     }
   }
 
-  rule child_created {
+  rule initialize_child_after_creation {
     select when wrangler child_created
+    pre {
+      rids_to_install = event:attr("rids_to_install")
+    }
+    if rids_to_install.length() > 0 then
+    noop()
+    fired {
+      raise wrangler event "install_rulesets_requested"
+        attributes event:attrs.put(["rids"], rids_to_install).put("init", true)
+    }
+    else {
+      raise wrangler event "finish_initialization"
+        attributes event:attrs
+    }
+  }
+
+  rule finish_child_initialization {
+    select when wrangler finish_initialization
       event:send({ "eci"   : event:attr("parent_eci"),
                    "domain": "wrangler", "type": "child_initialized",
                    "attrs" : event:attrs })
@@ -465,6 +493,7 @@ ruleset io.picolabs.wrangler {
         attributes event:attr("rs_attrs").put("dname",event:attr("name"))
     }
   }
+  
   // this pico is the primary pico
 
   rule pico_root_created {

--- a/packages/pico-engine/krl/io.picolabs.wrangler.krl
+++ b/packages/pico-engine/krl/io.picolabs.wrangler.krl
@@ -45,7 +45,7 @@ ruleset io.picolabs.wrangler {
 // ***                                                                                      ***
 // ********************************************************************************************
 
-  config= {"os_rids": [/*"io.picolabs.pds",*/"io.picolabs.wrangler","io.picolabs.visual_params"]}
+  config= {"os_rids": [/*"io.picolabs.pds",*/"io.picolabs.wrangler","io.picolabs.visual_params","io.picolabs.subscription"]}
   /*
        skyQuery is used to programmatically call function inside of other picos from inside a rule.
        parameters;

--- a/packages/pico-engine/krl/io.picolabs.wrangler.krl
+++ b/packages/pico-engine/krl/io.picolabs.wrangler.krl
@@ -356,7 +356,7 @@ ruleset io.picolabs.wrangler {
         attributes event:attrs.put(["rids"], rids{"rids"});
     }
     else {
-      error info "could not install rids, no rids attribute provided.";
+      error info "could not install rids: no valid rids provided";
     }
     finally {
       raise wrangler event "install_ruleset_error"
@@ -364,13 +364,6 @@ ruleset io.picolabs.wrangler {
       raise wrangler event "finish_initialization"
         attributes event:attrs  if initial_install == true;
       
-    }
-  }
-  
-  rule installRulesetFailure {
-    select when wrangler install_ruleset_error
-    always{
-      error info "could not install rids because they do not exist: " + event:attr("rids").join(", ")
     }
   }
 


### PR DESCRIPTION
#375 This pull request has a fix for this issue.

Changes:

- When a new child pico is created, rulesets are installed using the `install_rulesets_requested` rule for any user-requested rulesets to be installed on that child. OS rulesets (e.g. wrangler, visual_params) are still installed at the `createChild` defaction in wrangler. `child_initialized` is not sent back to the parent until any user-requested rulesets have been successful or failed in installation.
- Install rulesets rule now handles invalid rids, checking if an rid is registered with the engine before attempting install. If a given rid is not registered with the engine, wrangler will raise a `install_ruleset_error` event with attributes containing the names of the invalid rulesets. If no valid rids are given or no rids are given a system/error even is raised giving relevant information. 
- Added a new proxy rule to facilitate installing rulesets before sending a `child_initialized` event 


- Subscriptions automatically installed on child picos