### PR TITLE
Subscription create well-known bug

### DIFF
--- a/packages/pico-engine/krl/io.picolabs.subscription.krl
+++ b/packages/pico-engine/krl/io.picolabs.subscription.krl
@@ -141,7 +141,7 @@ ent:established [
   }//end global
 
   rule create_wellKnown_Rx{
-    select when wrangler ruleset_added where rids >< meta:rid
+    select when wrangler ruleset_added where event:attr("rids") >< meta:rid
     pre{ channel = wellKnown_Rx() }
     if(channel.isnull() || channel{"type"} != "Tx_Rx") then every{
       wrangler:newPolicy(wellknown_Policy) setting(__wellknown_Policy)

--- a/packages/pico-engine/krl/io.picolabs.wrangler.krl
+++ b/packages/pico-engine/krl/io.picolabs.wrangler.krl
@@ -45,7 +45,8 @@ ruleset io.picolabs.wrangler {
 // ***                                                                                      ***
 // ********************************************************************************************
 
-  config= {"os_rids": [/*"io.picolabs.pds",*/"io.picolabs.wrangler","io.picolabs.visual_params","io.picolabs.subscription"]}
+  config= {"os_rids"        : [/*"io.picolabs.pds",*/"io.picolabs.wrangler","io.picolabs.visual_params"],
+           "connection_rids": ["io.picolabs.subscription"] }
   /*
        skyQuery is used to programmatically call function inside of other picos from inside a rule.
        parameters;
@@ -293,7 +294,7 @@ ruleset io.picolabs.wrangler {
              "name": name,
              "id" : child{"id"},
              "eci": channel{"id"},
-             "rids_to_install": rids,
+             "rids_to_install": rids.defaultsTo([]).append(config{"connection_rids"}),
              "rs_attrs":event:attrs
             })
             });


### PR DESCRIPTION
This allows a well-known channel to be created when a subscriptions ruleset is installed automatically in every child pico. 