### PR TITLE
renamed intent to orphan event(API change)

### DIFF
--- a/packages/pico-engine/krl/io.picolabs.wrangler.krl
+++ b/packages/pico-engine/krl/io.picolabs.wrangler.krl
@@ -589,13 +589,13 @@ ruleset io.picolabs.wrangler {
     }
   }
 
-  rule pico_intent_to_orphan {
+  rule child_garbage_collection {
     select when wrangler delete_children
     foreach event:attr("subtreeArray") setting(child)
     every{
-      send_directive("notifying child of intent to kill", {"child": child});
+      send_directive("notifying child of intent to destroy", {"child": child});
       event:send({  "eci": child{"eci"}, "eid": 88,
-                    "domain": "pico", "type": "intent_to_orphan",
+                    "domain": "wrangler", "type": "garbage_collection",
                     "attrs": event:attrs });
     }
     always{


### PR DESCRIPTION
I changed pico intent_to_orphan event to wrangler garbage_collection. I believe this old event name was left over from merging "pico" ruleset into wranglers ruleset and does not reflect what the event is for. This is an API changing pull request that could break some existing code, but all tests passed for me.
Signed-off-by: Adam Burdett <adam@sovrin.org>