### PR TITLE
Updated CLI to make clear that the listen interface can be specified

### DIFF
--- a/packages/pico-engine/README.md
+++ b/packages/pico-engine/README.md
@@ -79,7 +79,7 @@ The server is configured via some environment variables.
 
  * `PORT` - what port the http server should listen on. By default it's `8080`
  * `PICO_ENGINE_HOME` - where the database and other files should be stored. By default it's `~/.pico-engine/`
- * `PICO_ENGINE_HOST` - the url prefix used to reach your engine, i.e. `"https://example.com"`. By default it's `"http://localhost:8080"`
+ * `PICO_ENGINE_HOST` - the hostname or IP address to listen on.  By default it's "http://localhost:8080"
 
 ## Contributing
 

--- a/packages/pico-engine/src/cli.js
+++ b/packages/pico-engine/src/cli.js
@@ -37,6 +37,7 @@ function main (args) {
     console.log('Environment variables')
     console.log("    PORT - what port the http server should listen on. By default it's 8080")
     console.log("    PICO_ENGINE_HOME - where the database and other files should be stored. By default it's ~/.pico-engine/")
+    console.log("    PICO_ENGINE_HOST - the hostname or IP address to listen on.  By default it's http://localhost:8080")
     console.log('')
     return
   }


### PR DESCRIPTION
CLI and documentation originally did not make clear that the interface to listen on can be specified.  This is useful for users who need to run on multi-homed systems.