### PR TITLE
use owner pico name as title

### DIFF
--- a/packages/pico-engine/public/js/index.js
+++ b/packages/pico-engine/public/js/index.js
@@ -604,6 +604,7 @@ $(document).ready(function () {
       document.title = $('body h1').html()
       if (data.picos && data.picos[0]) {
         $('#user-logout span').html(data.picos[0].dname)
+        document.title = data.picos[0].dname
       }
       $('div.pico')
         .resizable({


### PR DESCRIPTION
When a pico engine is set up to manage owner picos, it would be nice if the browser tab showed the name of the owner pico (instead of "My Picos"). This change makes that happen.