### PR TITLE
fixes so ent:map{..} has the same semantics as map{..}

### DIFF
--- a/packages/krl-stdlib/src/index.js
+++ b/packages/krl-stdlib/src/index.js
@@ -889,6 +889,9 @@ stdlib['get'] = function (ctx, obj, path) {
     return null
   }
   path = toKeyPath(path)
+  if (path.length === 0) {
+    return obj
+  }
   return _.get(obj, path, null)
 }
 
@@ -897,6 +900,9 @@ stdlib['set'] = function (ctx, obj, path, val) {
     return obj
   }
   path = toKeyPath(path)
+  if (path.length === 0) {
+    return val
+  }
   // TODO optimize
   obj = _.cloneDeep(obj)
   return _.set(obj, path, val)

--- a/packages/krl-stdlib/test.js
+++ b/packages/krl-stdlib/test.js
@@ -922,9 +922,15 @@ test('collection operators', async function (t) {
   tf('get', [obj, ['foo', 'bar', '10']], 'I like cheese')
   tf('get', [obj, 'colors'], 'many')
   tf('get', [obj, ['pi', 2]], 4)
+  tf('get', [obj, []], obj)
+  tf('get', [obj, null], null)
   assertObjNotMutated()
   tf('get', [['a', 'b', { 'c': ['d', 'e'] }], [2, 'c', 1]], 'e', 'get works on arrays and objects equally')
   tf('get', [['a', 'b', { 'c': ['d', 'e'] }], ['2', 'c', '1']], 'e', 'array indices can be strings')
+  tf('get', [{ 'null': 3, 'undefined': 4 }, null], 3)
+  tf('get', [{ 'null': 3, 'undefined': 4 }, NaN], 3, 'using KRL toString you get "null"')
+  tf('get', [{ 'null': 3, 'undefined': 4 }, undefined], 3)
+  tf('get', [{ 'null': 3, 'undefined': 4 }, 'undefined'], 4)
 
   tf('set', [obj, ['foo', 'baz'], 'qux'], {
     'colors': 'many',
@@ -961,6 +967,10 @@ test('collection operators', async function (t) {
     'pi': [3, 1, 4, 1, { a: 'wat?' }, 9, 3],
     'foo': { 'bar': { '10': 'I like cheese' } }
   })
+  tf('set', [obj, [], { a: 1, b: 2 }], { a: 1, b: 2 })
+  tf('set', [obj, null, { a: 1, b: 2 }], Object.assign({}, obj, {
+    'null': { a: 1, b: 2 }
+  }))
   assertObjNotMutated()
 
   tf('set', [['a', 'b', 'c'], [1], 'wat?'], ['a', 'wat?', 'c'])

--- a/packages/pico-engine-core/src/modules/index.js
+++ b/packages/pico-engine-core/src/modules/index.js
@@ -25,10 +25,15 @@ var normalizeId = function (domain, id) {
   if (_.has(id, 'key') && ktypes.isString(id.key)) {
     return {
       var_name: id.key,
-      query: id.path
+      query: ktypes.isArray(id.path)
+        ? id.path
+        : [id.path]
     }
   }
-  return { var_name: ktypes.toString(id) }
+  return {
+    var_name: ktypes.toString(id),
+    query: []
+  }
 }
 
 module.exports = function (core, thirdPartyModules) {

--- a/packages/pico-engine-core/test/index.test.js
+++ b/packages/pico-engine-core/test/index.test.js
@@ -2336,8 +2336,8 @@ test('PicoEngine - io.picolabs.persistent-index', async function (t) {
     [query('getBarKey', { key: 'aaa' }), 'blah'],
     [query('getFooKey', { key: '404' }), null],
     [query('getBarKey', { key: '404' }), null],
-    [query('getFooKey', {}), { aaa: 'blah', bbb: 'wat' }],
-    [query('getBarKey', {}), { aaa: 'blah', bbb: 'wat' }],
+    [query('getFooKey', {}), null],
+    [query('getBarKey', {}), null],
 
     [signal('pindex', 'delfoo', { key: 'aaa' }), []],
     [signal('pindex', 'delbar', { key: 'aaa' }), []],


### PR DESCRIPTION
`map{"key"}` is the same as `map{["key"]}`
`map{null}` is the same as `map{["null"]}`
`map{[]}` is the same as `map` i.e. `[]` is the path to the map's root
