### PR TITLE
dynamic raise statement - resolves #15

### DIFF
--- a/packages/krl-compiler/src/c/RaiseEventStatement.js
+++ b/packages/krl-compiler/src/c/RaiseEventStatement.js
@@ -1,11 +1,16 @@
 module.exports = function (ast, comp, e) {
-  var args = {
-    domain: e('string', ast.event_domain.value, ast.event_domain.loc),
-    type: comp(ast.event_type),
-    attributes: ast.event_attrs ? comp(ast.event_attrs) : e('nil'),
+  const args = {}
 
-    for_rid: ast.for_rid ? comp(ast.for_rid) : e('nil')
+  if (ast.event_domainAndType) {
+    args.domainAndType = comp(ast.event_domainAndType)
+  } else {
+    args.domain = e('string', ast.event_domain.value, ast.event_domain.loc)
+    args.type = comp(ast.event_type)
   }
+
+  args.attributes = ast.event_attrs ? comp(ast.event_attrs) : e('nil')
+
+  args.for_rid = ast.for_rid ? comp(ast.for_rid) : e('nil')
 
   return e(';', e('acall', e('id', 'ctx.raiseEvent'), [e('obj', args)]))
 }

--- a/packages/krl-generator/src/g/RaiseEventStatement.js
+++ b/packages/krl-generator/src/g/RaiseEventStatement.js
@@ -1,9 +1,14 @@
 module.exports = function (ast, ind, gen) {
   var src = ''
   src += ind() + 'raise '
-  src += gen(ast.event_domain)
-  src += ' event '
-  src += gen(ast.event_type)
+  if (ast.event_domainAndType) {
+    src += 'event '
+    src += gen(ast.event_domainAndType)
+  } else {
+    src += gen(ast.event_domain)
+    src += ' event '
+    src += gen(ast.event_type)
+  }
   if (ast.for_rid) {
     src += ' for ' + gen(ast.for_rid)
   }

--- a/packages/krl-parser/src/grammar.js
+++ b/packages/krl-parser/src/grammar.js
@@ -923,8 +923,24 @@ var grammar = {
             event_domain: data[1],
             event_type: data[3],
             event_attrs: (data[5] && data[5][1]) || null,
-        
             for_rid: data[4] ? data[4][1] : null,
+          };
+        }
+        },
+    {"name": "RaiseEventStatement$ebnf$3$subexpression$1", "symbols": [tok_for, "Expression"]},
+    {"name": "RaiseEventStatement$ebnf$3", "symbols": ["RaiseEventStatement$ebnf$3$subexpression$1"], "postprocess": id},
+    {"name": "RaiseEventStatement$ebnf$3", "symbols": [], "postprocess": function(d) {return null;}},
+    {"name": "RaiseEventStatement$ebnf$4$subexpression$1", "symbols": [tok_attributes, "Expression"]},
+    {"name": "RaiseEventStatement$ebnf$4", "symbols": ["RaiseEventStatement$ebnf$4$subexpression$1"], "postprocess": id},
+    {"name": "RaiseEventStatement$ebnf$4", "symbols": [], "postprocess": function(d) {return null;}},
+    {"name": "RaiseEventStatement", "symbols": [tok_raise, tok_event, "Expression", "RaiseEventStatement$ebnf$3", "RaiseEventStatement$ebnf$4"], "postprocess": 
+        function(data){
+          return {
+            loc: mkLoc(data),
+            type: "RaiseEventStatement",
+            event_domainAndType: data[2],
+            event_attrs: (data[4] && data[4][1]) || null,
+            for_rid: data[3] ? data[3][1] : null,
           };
         }
         },

--- a/packages/krl-parser/src/grammar.ne
+++ b/packages/krl-parser/src/grammar.ne
@@ -931,8 +931,21 @@ RaiseEventStatement -> %tok_raise Identifier %tok_event Expression
       event_domain: data[1],
       event_type: data[3],
       event_attrs: (data[5] && data[5][1]) || null,
-
       for_rid: data[4] ? data[4][1] : null,
+    };
+  }
+%}
+    | %tok_raise %tok_event Expression
+  (%tok_for Expression):?
+  (%tok_attributes Expression):?
+{%
+  function(data){
+    return {
+      loc: mkLoc(data),
+      type: "RaiseEventStatement",
+      event_domainAndType: data[2],
+      event_attrs: (data[4] && data[4][1]) || null,
+      for_rid: data[3] ? data[3][1] : null,
     };
   }
 %}

--- a/packages/krl-parser/tests/parser.test.js
+++ b/packages/krl-parser/tests/parser.test.js
@@ -1940,6 +1940,72 @@ test('raise event', function (t) {
     }
   ])
 
+  // dynamic event domain and type
+
+  testPostlude('raise event "foo:bar"', [
+    {
+      type: 'RaiseEventStatement',
+      event_domainAndType: mk('foo:bar'),
+      for_rid: null,
+      event_attrs: null
+    }
+  ])
+
+  testPostlude('raise event "foo:bar" for "some.rid.ok"', [
+    {
+      type: 'RaiseEventStatement',
+      event_domainAndType: mk('foo:bar'),
+      for_rid: mk('some.rid.ok'),
+      event_attrs: null
+    }
+  ])
+
+  testPostlude('raise event "foo:bar" attributes {"a":1,"b":2}', [
+    {
+      type: 'RaiseEventStatement',
+      event_domainAndType: mk('foo:bar'),
+      for_rid: null,
+      event_attrs: mk({ a: mk(1), b: mk(2) })
+    }
+  ])
+
+  testPostlude('raise event "foo:bar" for "some.rid.ok" attributes {"a":1,"b":2}', [
+    {
+      type: 'RaiseEventStatement',
+      event_domainAndType: mk('foo:bar'),
+      for_rid: mk('some.rid.ok'),
+      event_attrs: mk({ a: mk(1), b: mk(2) })
+    }
+  ])
+
+  testPostlude('raise event event', [
+    {
+      type: 'RaiseEventStatement',
+      event_domainAndType: mk.id('event'),
+      for_rid: null,
+      event_attrs: null
+    }
+  ])
+
+  testPostlude('raise event event attributes', [
+    {
+      type: 'RaiseEventStatement',
+      event_domain: mk.id('event'),
+      event_type: mk.id('attributes'),
+      for_rid: null,
+      event_attrs: null
+    }
+  ])
+
+  testPostlude('raise event event attributes {}', [
+    {
+      type: 'RaiseEventStatement',
+      event_domainAndType: mk.id('event'),
+      for_rid: null,
+      event_attrs: mk({})
+    }
+  ])
+
   t.end()
 })
 

--- a/packages/pico-engine-core/src/processEvent.js
+++ b/packages/pico-engine-core/src/processEvent.js
@@ -129,12 +129,18 @@ module.exports = async function processEvent (core, ctx) {
       var event = {
         eci: ctx.event.eci, // raise event is always to the same pico
         eid: ctx.event.eid, // inherit from parent event to aid in debugging
-        domain: revent.domain,
-        type: revent.type,
         attrs: revent.attributes,
         for_rid: revent.for_rid,
         txn_id: ctx.event.txn_id, // inherit from parent event
         timestamp: new Date()
+      }
+      if (revent.domainAndType) {
+        const parts = ktypes.toString(revent.domainAndType).replace(/\s+/g, '').split(':')
+        event.domain = parts[0]
+        event.type = parts.slice(1).join(':')
+      } else {
+        event.domain = revent.domain
+        event.type = revent.type
       }
       // must make a new ctx for this raise b/c it's a different event
       var raiseCtx = core.mkCTX({

--- a/packages/pico-engine-core/src/processEvent.js
+++ b/packages/pico-engine-core/src/processEvent.js
@@ -134,20 +134,23 @@ module.exports = async function processEvent (core, ctx) {
         txn_id: ctx.event.txn_id, // inherit from parent event
         timestamp: new Date()
       }
+      let domainTypeLog
       if (revent.domainAndType) {
         const parts = ktypes.toString(revent.domainAndType).replace(/\s+/g, '').split(':')
         event.domain = parts[0]
         event.type = parts.slice(1).join(':')
+        domainTypeLog = parts.join('/')
       } else {
         event.domain = revent.domain
         event.type = revent.type
+        domainTypeLog = event.domain + '/' + event.type
       }
       // must make a new ctx for this raise b/c it's a different event
       var raiseCtx = core.mkCTX({
         event: event,
         pico_id: ctx.pico_id// raise event is always to the same pico
       })
-      raiseCtx.emit('debug', 'adding raised event to schedule: ' + revent.domain + '/' + revent.type)
+      raiseCtx.emit('debug', 'adding raised event to schedule: ' + domainTypeLog)
       await addEventToSchedule(raiseCtx)
     },
     raiseError: function (ctx, level, data) {

--- a/packages/pico-engine-core/test/index.test.js
+++ b/packages/pico-engine-core/test/index.test.js
@@ -439,6 +439,16 @@ test('PicoEngine - io.picolabs.events ruleset', async function (t) {
     [query('getSentName'), 'Raised-3'],
 
     /// ///////////////////////////////////////////////////////////////////////
+    // Testing raise event <domainAndType>
+    [signal('events', 'raise_dynamic', { domainType: 'events:store_sent_name', name: 'Mr. Dynamic' }), []],
+    [query('getSentName'), 'Mr. Dynamic'],
+
+    [
+      signal('events', 'raise_dynamic', { domainType: 'events:get', thing: 'something?' }),
+      [{ name: 'get', options: { thing: 'something?' } }]
+    ],
+
+    /// ///////////////////////////////////////////////////////////////////////
     [
       signal('events', 'event_eid', {}, void 0, 'some eid for this test'),
       [{ name: 'event_eid', options: { eid: 'some eid for this test' } }]

--- a/test-rulesets/events.js
+++ b/test-rulesets/events.js
@@ -1179,6 +1179,49 @@ module.exports = {
         }
       }
     },
+    "raise_dynamic": {
+      "name": "raise_dynamic",
+      "select": {
+        "graph": {
+          "events": {
+            "raise_dynamic": {
+              "expr_0": async function (ctx, aggregateEvent, getAttrString, setting) {
+                var matches = [];
+                var m;
+                var j;
+                m = new RegExp("^(.*)$", "").exec(getAttrString(ctx, "domainType"));
+                if (!m)
+                  return false;
+                for (j = 1; j < m.length; j++)
+                  matches.push(m[j]);
+                setting("domainType", matches[0]);
+                return true;
+              }
+            }
+          }
+        },
+        "state_machine": {
+          "start": [[
+              "expr_0",
+              "end"
+            ]]
+        }
+      },
+      "body": async function (ctx, runAction, toPairs) {
+        var fired = true;
+        if (fired)
+          ctx.emit("debug", "fired");
+        else
+          ctx.emit("debug", "not fired");
+        if (fired) {
+          await ctx.raiseEvent({
+            "domainAndType": ctx.scope.get("domainType"),
+            "attributes": await ctx.modules.get(ctx, "event", "attrs"),
+            "for_rid": undefined
+          });
+        }
+      }
+    },
     "event_eid": {
       "name": "event_eid",
       "select": {

--- a/test-rulesets/events.krl
+++ b/test-rulesets/events.krl
@@ -243,6 +243,13 @@ ruleset io.picolabs.events {
                 attributes {"name": my_name}
         }
     }
+    rule raise_dynamic {
+        select when events raise_dynamic domainType re#^(.*)$# setting(domainType)
+        fired {
+            raise event domainType
+                attributes event:attrs
+        }
+    }
     rule event_eid {
         select when events event_eid
 


### PR DESCRIPTION
Adding new syntax for raise statements that allow a dynamic expression for the event domain

Original statement:
`raise <word> event <expression> [for <expression>] [attributes <expression>]`

New additional syntax:
`raise event <expression> [for <expression>] [attributes <expression>]`

For example:
```js
raise foo event "bar"
// - or -
raise event "foo:bar"
```

`raise event <expression> : <expression>` and `raise event <expression> <expression>` both had parser ambiguities, that's why there is a single expression for both the domain and type.

The domain-type expression is evaluated to a string (using KRL's toString logic) then the domain and type are parsed out separated by a `:`

