### PR TITLE
add picoQuery() as replacement or skyQuery()

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
     "setup": "npm i --no-package-lock && npm run bootstrap",
     "publish": "npm run build && lerna publish",
     "start": "cd packages/pico-engine && npm start",
-    "test": "lerna run test",
+    "test": "lerna run test && ava",
     "build": "cd packages/krl-parser && npm run build && cd ../krl-stdlib && npm run build && cd ../pico-engine-core && npm run build && cd ../pico-engine && npm run build"
   },
   "devDependencies": {
+    "ava": "^3.15.0",
     "lerna": "^3.2.1"
   }
 }


### PR DESCRIPTION
`picoQuery()` does what `skyQuery()` does AND also uses `ctx:query()` to query picos on the same engine instead of HTTP. This solves some policy problems on family channels and reduces the use of HTTP to just going off engine. 

A unified function in Wrangler means developers don't have to do this. 