### PR TITLE
add conditional checking before acessing internal object

### DIFF
--- a/packages/krl-compiler/bin/krl-compiler
+++ b/packages/krl-compiler/bin/krl-compiler
@@ -69,7 +69,9 @@ process.stdin.on("end", function(){
             process.exit(1);
             return;
         }
-        console.error(err.where.excerpt);
+         if (err?.where?.excerpt) {
+             console.error(err.where.excerpt);
+         }
         process.exit(1);
     }
     out.warnings.forEach(function(w){

--- a/packages/krl-compiler/bin/krl-compiler
+++ b/packages/krl-compiler/bin/krl-compiler
@@ -62,7 +62,9 @@ process.stdin.on("end", function(){
     try{
         out = compiler(src, opts);
     }catch(err){
-        console.error(err + ` [at line ${err.where.line} col ${err.where.col}]`);
+        if (err?.where?.line && err?.where?.col) {
+            console.error(err + ` [at line ${err.where.line} col ${err.where.col}]`);
+        }
         if(args.verify){
             process.exit(1);
             return;

--- a/packages/krl-compiler/bin/krl-compiler
+++ b/packages/krl-compiler/bin/krl-compiler
@@ -62,8 +62,9 @@ process.stdin.on("end", function(){
     try{
         out = compiler(src, opts);
     }catch(err){
+	console.error(err)
         if (err?.where?.line && err?.where?.col) {
-            console.error(err + ` [at line ${err.where.line} col ${err.where.col}]`);
+            console.error(` [at line ${err.where.line} col ${err.where.col}]`);
         }
         if(args.verify){
             process.exit(1);


### PR DESCRIPTION
This pull request is made to address the error I received when manually verifying a .krl file via piping the contents into `krl-compiler --verify` 
![image](https://user-images.githubusercontent.com/35553625/114439629-6f4a5f00-9b86-11eb-8f5d-11c0f44e892f.png)

Added code based off of https://github.com/Picolab/pico-engine/blob/e0291d58299dfbe86cd8d3ab4994a4492c3f3413/packages/pico-engine/src/server.ts#L243
