### PR TITLE
Fix error when ECI not found (#578)

### DIFF
--- a/packages/pico-engine-core/src/modules/schedule.ts
+++ b/packages/pico-engine-core/src/modules/schedule.ts
@@ -127,7 +127,10 @@ export function initScheduleModule(pf: PicoFramework) {
   function addScheduledEvent(rid: string, sEvent: ScheduledEvent) {
     if (sEvent.type === "at") {
       scheduler.addFuture(sEvent.id, sEvent.time, async () => {
-        const pico = pf.getPico(sEvent.event.eci);
+        let pico;
+        try {
+          pico = pf.getPico(sEvent.event.aci);
+        } catch (err) {}
         if (pico) {
           // TODO wrap in pico transaction
           const schedule = (await pico.getEnt(rid, "_schedule")) || {};
@@ -141,7 +144,10 @@ export function initScheduleModule(pf: PicoFramework) {
     } else if (sEvent.type === "repeat") {
       scheduler.addCron(sEvent.id, sEvent.timespec, async () => {
         let found = false;
-        const pico = pf.getPico(sEvent.event.eci);
+        let pico;
+        try {
+          pico = pf.getPico(sEvent.event.aci);
+        } catch (err) {}
         if (pico) {
           // TODO wrap in pico transaction
           const schedule = (await pico.getEnt(rid, "_schedule")) || {};


### PR DESCRIPTION
I'm not sure this would be the best way to do it; I only wrapped the getPico statement in a try/catch so that if the rest of the function throws an error, we don't have to worry about catching it unintentionally.
Could also be beneficial to add a try/catch directly in getPico in pico-framework.