### PR TITLE
Fix issue with scheduler crashing

### DIFF
--- a/packages/pico-engine-core/src/modules/schedule.ts
+++ b/packages/pico-engine-core/src/modules/schedule.ts
@@ -127,7 +127,10 @@ export function initScheduleModule(pf: PicoFramework) {
   function addScheduledEvent(rid: string, sEvent: ScheduledEvent) {
     if (sEvent.type === "at") {
       scheduler.addFuture(sEvent.id, sEvent.time, async () => {
-        const pico = pf.getPico(sEvent.event.eci);
+        let pico;
+        try {
+          pico = pf.getPico(sEvent.event.aci);
+        } catch (err) {}
         if (pico) {
           // TODO wrap in pico transaction
           const schedule = (await pico.getEnt(rid, "_schedule")) || {};
@@ -141,7 +144,10 @@ export function initScheduleModule(pf: PicoFramework) {
     } else if (sEvent.type === "repeat") {
       scheduler.addCron(sEvent.id, sEvent.timespec, async () => {
         let found = false;
-        const pico = pf.getPico(sEvent.event.eci);
+        let pico;
+        try {
+          pico = pf.getPico(sEvent.event.aci);
+        } catch (err) {}
         if (pico) {
           // TODO wrap in pico transaction
           const schedule = (await pico.getEnt(rid, "_schedule")) || {};

--- a/packages/pico-engine-core/src/modules/schedule.ts
+++ b/packages/pico-engine-core/src/modules/schedule.ts
@@ -129,7 +129,7 @@ export function initScheduleModule(pf: PicoFramework) {
       scheduler.addFuture(sEvent.id, sEvent.time, async () => {
         let pico;
         try {
-          pico = pf.getPico(sEvent.event.aci);
+          pico = pf.getPico(sEvent.event.eci);
         } catch (err) {}
         if (pico) {
           // TODO wrap in pico transaction
@@ -146,7 +146,7 @@ export function initScheduleModule(pf: PicoFramework) {
         let found = false;
         let pico;
         try {
-          pico = pf.getPico(sEvent.event.aci);
+          pico = pf.getPico(sEvent.event.eci);
         } catch (err) {}
         if (pico) {
           // TODO wrap in pico transaction


### PR DESCRIPTION
Fixes issue #578.
(New pull request for fixed changes. I had a typo in the original.)

The issue is caused by getPico() throwing an error instead of returning null when a pico with a given ECI is not found.