### PR TITLE
[#622] Add sub as option for event:send

### DIFF
--- a/packages/pico-engine-core/src/modules/event.ts
+++ b/packages/pico-engine-core/src/modules/event.ts
@@ -5,7 +5,7 @@ function eventProperty<T = any>(
   fn: (event: CurrentPicoEvent) => T
 ): (ctx: KrlCtx) => T | null {
   return krl.Property(function () {
-    let event = this.getEvent();
+    let event: any = this.getEvent();
     if (event) {
       return fn(event);
     }
@@ -34,6 +34,13 @@ const event: krl.Module = {
     ["options", "host"],
     async function event(options, host) {
       let eci = options.eci;
+      if (!eci)
+      {
+        if(options.sub) {
+          eci = options.sub.Tx
+          host = options.sub.Tx_host
+        }
+      }
       if (!krl.isString(eci)) {
         throw new TypeError(
           "eci was " +


### PR DESCRIPTION
Adds an option to specify a subscription in `event:send` instead of an `eci` as described in issue #622 .